### PR TITLE
feat (TextInput): not-allowed mouse cursor and color improvements to disabled input

### DIFF
--- a/src/components/TextInput/TextInput.jsx
+++ b/src/components/TextInput/TextInput.jsx
@@ -193,3 +193,4 @@ TextInput.defaultProps = {
 };
 
 export default TextInput;
+

--- a/src/components/TextInput/TextInput.scss
+++ b/src/components/TextInput/TextInput.scss
@@ -23,6 +23,11 @@
 
   &:disabled {
     color: $color-font-grey-light;
+    background-color: $color-base-grey-50;
+
+    &:hover {
+      cursor: not-allowed;
+    }
   }
 
   &:focus {

--- a/src/components/TextInput/TextInput.stories.jsx
+++ b/src/components/TextInput/TextInput.stories.jsx
@@ -44,7 +44,7 @@ StatefulInput.propTypes = {
 
 export const All = () => {
   const basicInputValue = 'Hello World!';
-  const disabledInputValue = 'I am disabled';
+  const disabledInputValue = 'Disabled value';
   const placeholderInputValue = '';
   const withLabelInputValue = 'With a label';
   const requiredInputValue = '';
@@ -59,7 +59,13 @@ export const All = () => {
         <StatefulInput initialValue={basicInputValue} />
       </div>
       <div style={{ marginBottom: '1rem' }}>
-        <StatefulInput initialValue={disabledInputValue} isDisabled />
+        <StatefulInput label="Disabled input with value" initialValue={disabledInputValue} isDisabled />
+      </div>
+      <div style={{ marginBottom: '1rem' }}>
+        <StatefulInput label="Disabled input without value" isDisabled />
+      </div>
+      <div style={{ marginBottom: '1rem' }}>
+        <StatefulInput label="Disabled input with placeholder" placeholder="I am placeholder inside disabled input" isDisabled />
       </div>
       <div style={{ marginBottom: '1rem' }}>
         <StatefulInput initialValue={withLabelInputValue} label="Name" />


### PR DESCRIPTION
<img width="478" alt="Screen Shot 2020-07-06 at 4 31 51 PM" src="https://user-images.githubusercontent.com/1447339/86667183-3bfaf400-bfa6-11ea-922b-1792fcd92e64.png">

Right now the grey colors are too blue, but waiting until Figma workflow is done to adjust. Also applies the "not-allowed" mouse cursor on hover so it's more obvious that a disabled input is disabled.