### PR TITLE
adding tokens as dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,9 @@
     "type": "git",
     "url": "https://github.com/palmetto/palmetto-components"
   },
+  "dependencies": {
+    "@palmetto/palmetto-design-tokens": "^0.1.9"
+  },
   "peerDependencies": {
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0"
@@ -42,7 +45,6 @@
   "devDependencies": {
     "@babel/core": "^7.10.3",
     "@babel/preset-react": "^7.10.4",
-    "@palmetto/palmetto-design-tokens": "^0.1.9",
     "@rollup/plugin-babel": "^5.0.4",
     "@rollup/plugin-commonjs": "^11.1.0",
     "@rollup/plugin-node-resolve": "^7.1.3",

--- a/src/components/CheckboxInput/CheckboxInput.scss
+++ b/src/components/CheckboxInput/CheckboxInput.scss
@@ -1,3 +1,5 @@
+@import '../../styles/variables.scss';
+
 .checkboxInput {
   display: flex;
   align-items: center;

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -1,7 +1,9 @@
 import TextInput from './TextInput/TextInput';
 import Heading from './Heading/Heading';
+import CheckboxInput from './CheckboxInput/CheckboxInput';
 
 export {
+  CheckboxInput,
   TextInput,
   Heading,
 };


### PR DESCRIPTION
palmetto-tokens needs to be added as a direct dependency of palmetto-components so that consumers don't have to install it explicitly.

This PR also adds the CheckboxInput to our index, hence exporting it for consumers.