### PR TITLE
ci: Run lint, unit tests and chromatic on pull requests

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -34,7 +34,9 @@ jobs:
     env:
       CI: true
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0 # Required to retrieve git history
       - uses: actions/cache@v1
         with:
           path: ~/.cache/yarn

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -10,13 +10,28 @@ on:
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
+  lint:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/cache@v1
+        with:
+          path: ~/.cache/yarn
+          key: ${{ runner.os }}-yarn-${{ hashFiles(format('{0}{1}', github.workspace, '/yarn.lock')) }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+      - name: install dependencies
+        run: yarn install
+      - name: lint
+        run: yarn lint
   unit-tests:
     name: unit tests
     runs-on: ubuntu-latest
     env:
       CI: true
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - uses: actions/cache@v1
         with:
           path: ~/.cache/yarn

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,0 +1,50 @@
+# This is a basic workflow to help you get started with Actions
+
+name: Pull Request
+
+# Controls when the action will run. Triggers the workflow on push or pull request
+# events but only for the master branch
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  unit-tests:
+    name: unit tests
+    runs-on: ubuntu-latest
+    env:
+      CI: true
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/cache@v1
+        with:
+          path: ~/.cache/yarn
+          key: ${{ runner.os }}-yarn-${{ hashFiles(format('{0}{1}', github.workspace, '/yarn.lock')) }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+      - name: install dependencies
+        run: yarn install
+      - name: unit test
+        run: |
+          yarn test
+  visual-tests:
+    name: visual regression tests
+    runs-on: ubuntu-latest
+    env:
+      CI: true
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/cache@v1
+        with:
+          path: ~/.cache/yarn
+          key: ${{ runner.os }}-yarn-${{ hashFiles(format('{0}{1}', github.workspace, '/yarn.lock')) }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+      - name: install dependencies
+        run: yarn install
+      - uses: chromaui/action@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -1,7 +1,7 @@
 import Button from './Button/Button';
 import CheckboxInput from './CheckboxInput/CheckboxInput';
-import FormikCheckboxInput from './FormikCheckboxInput/FormikCheckboxInput';
-import FormikTextInput from './FormikTextInput/FormikTextInput';
+import FormikCheckboxInput from './Formik/FormikCheckboxInput/FormikCheckboxInput';
+import FormikTextInput from './Formik/FormikTextInput/FormikTextInput';
 import Heading from './Heading/Heading';
 import TextInput from './TextInput/TextInput';
 


### PR DESCRIPTION
This makes it so that the following are run when a pull request is opened, synchronized, or reopened.

1. lint
2. unit tests
3. visual regression tests

Once this is merged, I want to make these checks required before merging is allowed.