### PR TITLE
feat: adding maxlength prop on TextINput

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -4,6 +4,10 @@
       "presets": [
         ["@babel/preset-env", { "modules": "cjs" }],
         "@babel/preset-react"
+      ],
+      "plugins": [
+        "@babel/plugin-transform-regenerator",
+        "@babel/plugin-transform-runtime"
       ]
     },
     "build": {

--- a/package.json
+++ b/package.json
@@ -45,6 +45,8 @@
   },
   "devDependencies": {
     "@babel/core": "^7.10.3",
+    "@babel/plugin-transform-regenerator": "^7.10.4",
+    "@babel/plugin-transform-runtime": "^7.10.4",
     "@babel/polyfill": "^7.10.4",
     "@babel/preset-react": "^7.10.4",
     "@rollup/plugin-babel": "^5.0.4",

--- a/src/components/TextInput/TextInput.jsx
+++ b/src/components/TextInput/TextInput.jsx
@@ -27,6 +27,7 @@ const TextInput = ({
   error,
   isRequired,
   label,
+  maxLength,
   name,
   onBlur,
   onChange,
@@ -77,6 +78,7 @@ const TextInput = ({
     className: inputClasses,
     disabled: isDisabled,
     id,
+    maxLength,
     name,
     onBlur: handleBlur,
     onChange: handleChange,
@@ -157,6 +159,11 @@ TextInput.propTypes = {
    */
   label: PropTypes.string,
   /**
+   * The input's 'maxlength' attribute.
+   * NOTE: initializing the input with a value longer than the desired maxlength will not trim this value.
+   */
+  maxLength: PropTypes.string,
+  /**
    * The input's 'name' attribute
    */
   name: PropTypes.string,
@@ -195,6 +202,7 @@ TextInput.defaultProps = {
   error: false,
   isRequired: false,
   label: undefined,
+  maxLength: undefined,
   name: '',
   onBlur: undefined,
   onFocus: undefined,

--- a/src/components/TextInput/TextInput.stories.jsx
+++ b/src/components/TextInput/TextInput.stories.jsx
@@ -22,6 +22,7 @@ export const All = () => {
     withLabelErrorInputValue: 'invalid value',
     withValidationMessage: '',
     invalidWithLabel: '',
+    withMaxLength: 'asdhasdhasdh',
   });
 
   const handleChange = (event, key) => {
@@ -150,6 +151,15 @@ export const All = () => {
               value={state.invalidWithLabel}
               label="Invalid With Label"
               onChange={event => handleChange(event, 'invalidWithLabel')}
+            />
+          </div>
+          <div style={{ marginBottom: '1rem' }}>
+            <TextInput
+              id="withMaxLength"
+              maxLength="5"
+              value={state.withMaxLength}
+              label="Can't enter more than 5 characters"
+              onChange={event => handleChange(event, 'withMaxLength')}
             />
           </div>
         </div>

--- a/src/components/TextInput/TextInput.test.jsx
+++ b/src/components/TextInput/TextInput.test.jsx
@@ -5,6 +5,7 @@ import {
   screen,
 } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
+import userEvent from '@testing-library/user-event';
 import TextInput from './TextInput';
 
 describe('TextInput', () => {
@@ -156,5 +157,24 @@ describe('TextInput', () => {
     const validationMessageElement = screen.getByText('You silly goose');
     expect(validationMessageElement).toBeInTheDocument();
     expect(validationMessageElement).toHaveTextContent('You silly goose');
+  });
+
+  test('Input correctly passes maxlength property if prop is passed', async () => {
+    render(
+      <TextInput
+        name="firstName"
+        id="firstName"
+        label="first name"
+        value=""
+        maxLength="3"
+        onChange={() => null}
+      />,
+    );
+
+    const inputElement = screen.getByLabelText('first name');
+    expect(inputElement).toBeInTheDocument();
+    expect(inputElement).toHaveAttribute('maxlength');
+    expect(inputElement.getAttribute('maxlength')).toBe('3');
+    expect(inputElement.value).toBe('');
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1547,6 +1547,16 @@
     resolve "^1.8.1"
     semver "^5.5.1"
 
+"@babel/plugin-transform-runtime@^7.10.4":
+  version "7.10.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.10.4.tgz#594fb53453ea1b6f0779cceb48ce0718a447feb7"
+  integrity sha512-8ULlGv8p+Vuxu+kz2Y1dk6MYS2b/Dki+NO6/0ZlfSj5tMalfDL7jI/o/2a+rrWLqSXvnadEqc2WguB4gdQIxZw==
+  dependencies:
+    "@babel/helper-module-imports" "^7.10.4"
+    "@babel/helper-plugin-utils" "^7.10.4"
+    resolve "^1.8.1"
+    semver "^5.5.1"
+
 "@babel/plugin-transform-shorthand-properties@^7.10.1", "@babel/plugin-transform-shorthand-properties@^7.8.3":
   version "7.10.1"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.10.1.tgz#e8b54f238a1ccbae482c4dce946180ae7b3143f3"


### PR DESCRIPTION
NOTE: the babel plugins are to allow async/await usage with jest tests. not used currently but it will be useful when testing events with `userEvent`