### PR TITLE
chore: refactor checkbox input API and corresponding components

### DIFF
--- a/src/components/CheckboxInput/CheckboxInput.jsx
+++ b/src/components/CheckboxInput/CheckboxInput.jsx
@@ -16,17 +16,22 @@ const CheckboxInput = ({
   isChecked,
   isDisabled,
   isRequired,
+  onBlur,
   onChange,
+  onFocus,
   label,
 }) => {
-  const handleChange = e => {
-    onChange(e.target.checked);
+  const handleBlur = e => {
+    if (onBlur) onBlur(e);
   };
 
-  // const labelClasses = classNames(
-  //   'checkboxInputInstructions',
-  //   { error },
-  // );
+  const handleChange = e => {
+    onChange(e);
+  };
+
+  const handleFocus = e => {
+    if (onFocus) onFocus(e);
+  };
 
   const labelProps = {
     isFieldRequired: isRequired,
@@ -43,7 +48,9 @@ const CheckboxInput = ({
           id={id}
           checked={isChecked}
           disabled={isDisabled}
+          onBlur={handleBlur}
           onChange={handleChange}
+          onFocus={handleFocus}
           type="checkbox"
           className="input"
         />
@@ -60,6 +67,8 @@ CheckboxInput.defaultProps = {
   isChecked: false,
   isDisabled: false,
   isRequired: false,
+  onBlur: undefined,
+  onFocus: undefined,
 };
 
 CheckboxInput.propTypes = {
@@ -93,9 +102,17 @@ CheckboxInput.propTypes = {
    */
   isRequired: PropTypes.bool,
   /**
+   * Callback function when input is blurred.
+   */
+  onBlur: PropTypes.func,
+  /**
    * Callback function when input is changed
    */
   onChange: PropTypes.func.isRequired,
+  /**
+   * Callback function when input is focused
+   */
+  onFocus: PropTypes.func,
   /**
    * Custom content to be displayed to right of checkbox. Can be any valid node/tree, anchors, etc.
    */

--- a/src/components/CheckboxInput/CheckboxInput.stories.jsx
+++ b/src/components/CheckboxInput/CheckboxInput.stories.jsx
@@ -22,9 +22,9 @@ export const All = () => {
     withErrorRequired: false,
   });
 
-  const handleChange = (value, key) => {
-    action('change')(value);
-    store.set({ [key]: value });
+  const handleChange = (event, key) => {
+    action('change')(event);
+    store.set({ [key]: event.target.checked });
   };
 
   return (

--- a/src/components/CheckboxInput/CheckboxInput.test.jsx
+++ b/src/components/CheckboxInput/CheckboxInput.test.jsx
@@ -12,7 +12,7 @@ describe('CheckboxInput', () => {
       <CheckboxInput
         id="testCheckbox"
         label="test checkbox"
-        value="hello"
+        isChecked={false}
         onChange={() => null}
       />,
     );
@@ -28,8 +28,8 @@ describe('CheckboxInput', () => {
       <CheckboxInput
         id="testCheckbox"
         label="test checkbox"
-        value="hello"
         onChange={() => null}
+        isChecked={false}
       />,
     );
     expect(getByLabelText('test checkbox')).toBeDefined();
@@ -40,7 +40,6 @@ describe('CheckboxInput', () => {
       <CheckboxInput
         id="testCheckbox"
         label="test checkbox"
-        value="hello"
         onChange={() => null}
         isChecked
       />,
@@ -54,9 +53,8 @@ describe('CheckboxInput', () => {
       <CheckboxInput
         id="testCheckbox"
         label="test checkbox"
-        value="hello"
-        onChange={() => null}
         isChecked={false}
+        onChange={() => null}
       />,
     );
     const checkbox = getByLabelText('test checkbox');
@@ -71,7 +69,7 @@ describe('CheckboxInput', () => {
         <CheckboxInput
           id="testCheckbox"
           label="test checkbox"
-          value="hello"
+          isChecked={false}
           onChange={mockedHandleChange}
         />,
       );
@@ -80,37 +78,22 @@ describe('CheckboxInput', () => {
       expect(mockedHandleChange).toHaveBeenCalledTimes(1);
     });
 
-    test('calls onChange with true when isCheck is false', () => {
-      const mockedHandleChange = jest.fn(() => null);
+    test('calls onChange and passes checked value in event', () => {
+      let value = true;
+      const mockedHandleChange = jest.fn(event => { value = event.target.checked; });
 
       const { getByLabelText } = render(
         <CheckboxInput
           id="testCheckbox"
           label="test checkbox"
-          value="hello"
           onChange={mockedHandleChange}
+          isChecked={value}
         />,
       );
       const checkbox = getByLabelText('test checkbox');
       fireEvent.click(checkbox);
-      expect(mockedHandleChange).toHaveBeenCalledWith(true);
-    });
-
-    test('calls onChange with false when isChecked when true', () => {
-      const mockedHandleChange = jest.fn(() => null);
-
-      const { getByLabelText } = render(
-        <CheckboxInput
-          id="testCheckbox"
-          label="test checkbox"
-          value="hello"
-          onChange={mockedHandleChange}
-          isChecked
-        />,
-      );
-      const checkbox = getByLabelText('test checkbox');
-      fireEvent.click(checkbox);
-      expect(mockedHandleChange).toHaveBeenCalledWith(false);
+      expect(mockedHandleChange).toBeCalledTimes(1);
+      expect(value).toBe(false);
     });
   });
 });

--- a/src/components/Formik/FormikCheckboxInput/FormikCheckboxInput.jsx
+++ b/src/components/Formik/FormikCheckboxInput/FormikCheckboxInput.jsx
@@ -10,7 +10,7 @@ const FormikCheckboxInput = (
       onChange, // eslint-disable-line no-unused-vars
       value,
     },
-    form: { touched, setFieldValue, errors },
+    form: { touched, errors },
     ...props
   },
 ) => (
@@ -18,7 +18,8 @@ const FormikCheckboxInput = (
     {...props}
     error={touched[name] && errors[name]}
     isChecked={value}
-    onChange={newValue => setFieldValue(name, newValue)}
+    onBlur={onBlur}
+    onChange={onChange}
   />
 );
 


### PR DESCRIPTION
The `CheckboxInput` component now passes a full synthetic event back to library consumers when onChange fires. Corresponding tests, stories, and Formik binding have been changed accordingly.