### PR TITLE
fix: prevent empty class properties appearing in the dom

### DIFF
--- a/src/components/Button/Button.jsx
+++ b/src/components/Button/Button.jsx
@@ -53,7 +53,7 @@ const propTypes = {
 const defaultProps = {
   id: undefined,
   type: 'button',
-  className: '',
+  className: undefined,
   isDisabled: false,
   isLoading: undefined,
   fullWidth: undefined,

--- a/src/components/CheckboxInput/CheckboxInput.jsx
+++ b/src/components/CheckboxInput/CheckboxInput.jsx
@@ -58,7 +58,7 @@ const propTypes = {
 };
 
 const defaultProps = {
-  className: '',
+  className: undefined,
   error: false,
   isChecked: false,
   isDisabled: false,

--- a/src/components/SelectInput/SelectInput.jsx
+++ b/src/components/SelectInput/SelectInput.jsx
@@ -91,7 +91,7 @@ const propTypes = {
 };
 
 const defaultProps = {
-  className: '',
+  className: undefined,
   placeholder: undefined,
   error: false,
   hideLabel: false,

--- a/src/components/TextInput/TextInput.jsx
+++ b/src/components/TextInput/TextInput.jsx
@@ -104,7 +104,7 @@ const propTypes = {
 const defaultProps = {
   autoComplete: false,
   autoFocus: false,
-  className: '',
+  className: undefined,
   hideLabel: false,
   inputMask: undefined,
   isDisabled: false,


### PR DESCRIPTION
fixes empty class properties appearing in the dom: 

currently
<img width="1389" alt="Screen Shot 2020-07-17 at 12 26 08 PM" src="https://user-images.githubusercontent.com/1447339/87823717-cbb36480-c828-11ea-8c78-5c695335a6f6.png">
