### PR TITLE
security: bump codecov from 3.7.0 to 3.7.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "chromatic": "^4.0.3",
     "classnames": "^2.2.6",
     "cleave.js": "^1.6.0",
-    "codecov": "^3.7.0",
+    "codecov": "^3.7.1",
     "css-loader": "^3.6.0",
     "eslint": "^7.3.1",
     "eslint-config-airbnb": "^18.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5784,9 +5784,9 @@ code-point-at@^1.0.0:
   integrity sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=
 
 codecov@^3.7.0:
-  version "3.7.0"
-  resolved "https://registry.yarnpkg.com/codecov/-/codecov-3.7.0.tgz#4a09939cde24447a43f36d068e8b4e0188dc3f27"
-  integrity sha512-uIixKofG099NbUDyzRk1HdGtaG8O+PBUAg3wfmjwXw2+ek+PZp+puRvbTohqrVfuudaezivJHFgTtSC3M8MXww==
+  version "3.7.1"
+  resolved "https://registry.yarnpkg.com/codecov/-/codecov-3.7.1.tgz#434cb8d55f18ef01672e5739d3d266696bebc202"
+  integrity sha512-JHWxyPTkMLLJn9SmKJnwAnvY09kg2Os2+Ux+GG7LwZ9g8gzDDISpIN5wAsH1UBaafA/yGcd3KofMaorE8qd6Lw==
   dependencies:
     argv "0.0.2"
     ignore-walk "3.0.3"


### PR DESCRIPTION
https://github.com/advisories/GHSA-5q88-cjfq-g2mh