### PR TITLE
Setup Theming

### DIFF
--- a/.storybook/manager.js
+++ b/.storybook/manager.js
@@ -1,0 +1,6 @@
+import { addons } from '@storybook/addons';
+import palmettoTheme from './palmettoTheme';
+
+addons.setConfig({
+  theme: palmettoTheme,
+});

--- a/.storybook/palmettoTheme.js
+++ b/.storybook/palmettoTheme.js
@@ -1,7 +1,7 @@
 import { create } from '@storybook/theming/create';
 
 export default create({
-  base: 'light',
+  base: 'dark',
 
   // colorPrimary: 'hotpink',
   // colorSecondary: 'deepskyblue',

--- a/.storybook/palmettoTheme.js
+++ b/.storybook/palmettoTheme.js
@@ -1,0 +1,37 @@
+import { create } from '@storybook/theming/create';
+
+export default create({
+  base: 'light',
+
+  // colorPrimary: 'hotpink',
+  // colorSecondary: 'deepskyblue',
+
+  // // UI
+  // appBg: 'white',
+  // appContentBg: 'silver',
+  // appBorderColor: 'grey',
+  // appBorderRadius: 4,
+
+  // // Typography
+  // fontBase: '"Open Sans", sans-serif',
+  // fontCode: 'monospace',
+
+  // // Text colors
+  // textColor: 'black',
+  // textInverseColor: 'rgba(255,255,255,0.9)',
+
+  // // Toolbar default and active colors
+  // barTextColor: 'silver',
+  // barSelectedColor: 'black',
+  // barBg: 'hotpink',
+
+  // // Form colors
+  // inputBg: 'white',
+  // inputBorder: 'silver',
+  // inputTextColor: 'black',
+  // inputBorderRadius: 4,
+
+  brandTitle: 'Palmetto Component Library',
+  brandUrl: 'https://palmetto.com',
+  brandImage: 'https://alchemy.palmetto.com/public//default_logo/1541461188.png',
+});

--- a/.storybook/palmettoTheme.js
+++ b/.storybook/palmettoTheme.js
@@ -1,7 +1,7 @@
 import { create } from '@storybook/theming/create';
 
 export default create({
-  base: 'dark',
+  base: 'light',
 
   // colorPrimary: 'hotpink',
   // colorSecondary: 'deepskyblue',

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,0 +1,9 @@
+import { addParameters } from '@storybook/react';
+import { themes } from '@storybook/theming';
+import palmettoTheme from './palmettoTheme';
+
+addParameters({
+  options: {
+    theme: palmettoTheme,
+  },
+});

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "@storybook/addon-viewport": "^5.3.19",
     "@storybook/addons": "^5.3.19",
     "@storybook/react": "^5.3.19",
+    "@storybook/theming": "^5.3.19",
     "@svgr/rollup": "^5.4.0",
     "@svgr/webpack": "^5.4.0",
     "@testing-library/jest-dom": "^5.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3121,7 +3121,7 @@
     prop-types "^15.7.2"
     regenerator-runtime "^0.13.3"
 
-"@storybook/theming@5.3.19":
+"@storybook/theming@5.3.19", "@storybook/theming@^5.3.19":
   version "5.3.19"
   resolved "https://registry.yarnpkg.com/@storybook/theming/-/theming-5.3.19.tgz#177d9819bd64f7a1a6ea2f1920ffa5baf9a5f467"
   integrity sha512-ecG+Rq3hc1GOzKHamYnD4wZ0PEP9nNg0mXbC3RhbxfHj+pMMCWWmx9B2Uu75SL1PTT8WcfkFO0hU/0IO84Pzlg==


### PR DESCRIPTION
Came across theming in the docs and just had to give it a go; swapped in Palmetto's logo for starters, then switched the theme to "dark" just to see what it would look like. Figure we can at least go with the logo change for now, just so the setup is committed to the repo for future use.

https://storybook.js.org/docs/configurations/theming/

<img width="589" alt="Screen Shot 2020-08-06 at 4 24 59 PM" src="https://user-images.githubusercontent.com/5695990/89592630-ef534480-d801-11ea-83cb-3d270cb41bc7.png">

<img width="681" alt="Screen Shot 2020-08-06 at 5 04 58 PM" src="https://user-images.githubusercontent.com/5695990/89594559-0183b180-d807-11ea-85b5-46278794238f.png">
