### PR TITLE
Form label refactor

### DIFF
--- a/src/components/CheckboxInput/CheckboxInput.module.scss
+++ b/src/components/CheckboxInput/CheckboxInput.module.scss
@@ -6,6 +6,10 @@
     pointer-events: none;
   }
 
+  &.inline {
+    display: inline-flex;
+  }
+
   .input {
     margin: 0 var(--size-spacing-sm) 0 0;
     width: var(--size-spacing-lg);

--- a/src/components/CheckboxInput/CheckboxInput.stories.mdx
+++ b/src/components/CheckboxInput/CheckboxInput.stories.mdx
@@ -3,6 +3,7 @@ import { action } from '@storybook/addon-actions';
 import { withA11y } from '@storybook/addon-a11y';
 import { Meta, Story, Preview, Props } from '@storybook/addon-docs/blocks';
 import CheckboxInput from './CheckboxInput';
+import FormLabel from '../FormLabel/FormLabel';
 
 <Meta
   title="Components/Form Inputs/CheckboxInput"
@@ -79,29 +80,54 @@ Use the `isChecked` prop to mark the input as checked upon initial render.
   </Story>
 </Preview>
 
+## Hidden Label
+
+The `label` is a required prop, but if you need to hide it for stylistic reasons, you can do
+so with the `hideLabel` prop. The checkbox will still utilize the label string value to
+populate the `aria-label` property on the input for accessibility reasons.
+
+<Preview>
+  <Story name="Hidden Label">
+    {() => {
+      const [value, setValue] = useState(null);
+      return (
+        <CheckboxInput
+          id="hiddenLabel"
+          hideLabel
+          onChange={value => setValue(event.target.checked)}
+          isChecked={value}
+        />
+      );
+    }}
+  </Story>
+</Preview>
+
 ## Custom Label
 
-Pass simple strings or any valid DOM node(s) to `label` to create custom labels.
+If you require a label with custom markup,
+simply hide the default label (remember to still pass a text value for the label)
+and append your own. Feel free to use the `FormLabel` component to keep the base text styles consistent.
 
 <Preview>
   <Story name="Custom Label">
     {() => {
       const [value, setValue] = useState(null);
       return (
-        <CheckboxInput
-          id="customLabel"
-          label={(
-            <span>
-              <span style={{ color: '#5620c5' }}>
-                Pass any element(s) as children for the label, even links! Add custom styles.
-              </span>
-              {' '}
-              <a href="https://www.palmetto.com">Go to Palmetto.com</a>
-            </span>
-          )}
-          onChange={value => setValue(event.target.checked)}
-          isChecked={value}
-        />
+          <>
+            <CheckboxInput
+              id="customLabel"
+              label="This label is custom"
+              hideLabel
+              onChange={value => setValue(event.target.checked)}
+              isChecked={value}
+              displayInline
+            />
+            <div style={{ display: 'inline-flex', verticalAlign: 'super' }}>
+              <FormLabel inputId="customLabel">
+                This is custom, look at this <a href="https://palmetto.com" onClick={() => alert('hey you clicked me!')} target="_blank">Link</a>
+              </FormLabel>
+            </div>
+          </>
       );
     }}
   </Story>

--- a/src/components/CheckboxInput/CheckboxInput.test.jsx
+++ b/src/components/CheckboxInput/CheckboxInput.test.jsx
@@ -48,7 +48,7 @@ describe('CheckboxInput', () => {
       inputId: 'testCheckbox',
       hasError: false,
       isFieldRequired: false,
-      labelText: 'test checkbox',
+      children: 'test checkbox',
       className: undefined,
       isDisabled: false,
     }, {});
@@ -70,7 +70,7 @@ describe('CheckboxInput', () => {
       inputId: 'testCheckbox',
       hasError: false,
       isFieldRequired: true,
-      labelText: 'test checkbox',
+      children: 'test checkbox',
       className: undefined,
       isDisabled: false,
     }, {});
@@ -143,7 +143,7 @@ describe('CheckboxInput', () => {
         inputId: 'testCheckbox',
         hasError: true,
         isFieldRequired: false,
-        labelText: 'test checkbox',
+        children: 'test checkbox',
         className: undefined,
         isDisabled: false,
       }, {});
@@ -164,7 +164,7 @@ describe('CheckboxInput', () => {
         inputId: 'testCheckbox',
         hasError: true,
         isFieldRequired: false,
-        labelText: 'test checkbox',
+        children: 'test checkbox',
         className: undefined,
         isDisabled: false,
       }, {});
@@ -186,7 +186,7 @@ describe('CheckboxInput', () => {
       inputId: 'testCheckbox',
       hasError: false,
       isFieldRequired: false,
-      labelText: 'test checkbox',
+      children: 'test checkbox',
       className: undefined,
       isDisabled: true,
     }, {});

--- a/src/components/CheckboxInput/CheckboxInput.tsx
+++ b/src/components/CheckboxInput/CheckboxInput.tsx
@@ -28,6 +28,15 @@ interface Props {
    */
   label: string;
   /**
+   * Determines if the label is not shown for stylistic reasons.
+   * Note the label is still a required prop and will be used as the aria-label for accesibility reasons.
+   */
+  hideLabel?: boolean;
+  /**
+   * Determines if the checkbox should be rendered with display: inline;
+   */
+  displayInline?: boolean;
+  /**
    * Additional classes to add
    */
   className?: string;
@@ -59,6 +68,8 @@ const CheckboxInput: FC<Props> = ({
   isChecked,
   onChange,
   label,
+  hideLabel = false,
+  displayInline = false,
   className,
   error = false,
   isDisabled = false,
@@ -82,34 +93,38 @@ const CheckboxInput: FC<Props> = ({
     styles.checkbox,
     className,
     { [styles.disabled]: isDisabled },
+    { [styles.inline]: displayInline },
   );
+
+  const inputProps = {
+    'aria-invalid': !!error,
+    'aria-label': label,
+    'aria-labelledby': label ? `${id}Label` : undefined,
+    id,
+    checked: !!isChecked,
+    disabled: isDisabled,
+    onBlur: handleBlur,
+    onChange: handleChange,
+    onFocus: handleFocus,
+    type: 'checkbox',
+    className: styles.input,
+  };
+
+  const labelProps = {
+    isFieldRequired: isRequired,
+    inputId: id,
+    hasError: !!error,
+    isDisabled,
+  };
 
   return (
     <>
       <div className={wrapperClasses}>
-        <input
-          aria-invalid={!!error}
-          aria-label={label}
-          aria-labelledby={label ? `${id}Label` : undefined}
-          id={id}
-          checked={!!isChecked}
-          disabled={isDisabled}
-          onBlur={handleBlur}
-          onChange={handleChange}
-          onFocus={handleFocus}
-          type="checkbox"
-          className={styles.input}
-        />
-        {label && (
-          <FormLabel
-            {...{
-              isFieldRequired: isRequired,
-              inputId: id,
-              labelText: label,
-              hasError: !!error,
-              isDisabled,
-            }}
-          />
+        <input {...inputProps} />
+        {label && !hideLabel && (
+          <FormLabel {...labelProps}>
+            {label}
+          </FormLabel>
         )}
       </div>
       {error && error !== true && <InputValidationMessage>{error}</InputValidationMessage>}

--- a/src/components/FormLabel/FormLabel.module.scss
+++ b/src/components/FormLabel/FormLabel.module.scss
@@ -7,7 +7,7 @@
   font-weight: 700;
 
   &.inline {
-    display: inline-block;
+    display: inline;
   }
 
   &.radio-input-label {

--- a/src/components/FormLabel/FormLabel.stories.mdx
+++ b/src/components/FormLabel/FormLabel.stories.mdx
@@ -1,0 +1,53 @@
+import FormLabel from './FormLabel';
+import { action } from '@storybook/addon-actions';
+import { withA11y } from '@storybook/addon-a11y';
+import { Meta, Story, Preview, Props } from '@storybook/addon-docs/blocks';
+
+<Meta
+  title="Components/Form Inputs/Subcomponents/FormLabel"
+  component={FormLabel}
+  decorators={[withA11y]}
+/>
+
+# FormLabel
+
+FormLabel is a subcomponent of form inputs but can be used independently in unique cases
+where we want to use the consistent styles for the component with custom JSX content.
+
+## Props
+<Props of={FormLabel} />
+
+<Preview>
+  <Story name="Default">
+    <FormLabel>Default Label</FormLabel>
+  </Story>
+</Preview>
+
+<Preview>
+  <Story name="Required">
+    <FormLabel inputId="name" isFieldRequired>required input label</FormLabel>
+  </Story>
+</Preview>
+
+
+<Preview>
+  <Story name="Error States">
+    <>
+    <FormLabel inputId="name" hasError>input label has error</FormLabel>
+    <FormLabel inputId="name" hasError isFieldRequired>required input label has error</FormLabel>
+    </>
+  </Story>
+</Preview>
+
+<Preview>
+  <Story name="More than just text">
+    <>
+    <FormLabel inputId="name">
+      This label has a span with
+      <span style={{ fontStyle: 'italic' }}>&nbsp;Italic&nbsp;</span>
+      and also a&nbsp;
+      <a href="https://palmetto.com" target="_blank">Link</a>
+    </FormLabel>
+    </>
+  </Story>
+</Preview>

--- a/src/components/FormLabel/FormLabel.test.jsx
+++ b/src/components/FormLabel/FormLabel.test.jsx
@@ -12,26 +12,26 @@ afterEach(() => {
 
 describe('FormLabel', () => {
   test('Label correctly renders with base props', () => {
-    render(<FormLabel inputId="myId" labelText="my label" />);
+    render(<FormLabel inputId="myId">my label</FormLabel>);
     const labelElement = screen.getByText('my label');
     expect(labelElement).toHaveAttribute('for', 'myId');
     expect(labelElement).toHaveTextContent('my label');
   });
 
   test('Label correctly renders with askterisk if field is required', () => {
-    render(<FormLabel inputId="myId" labelText="my label" isFieldRequired />);
+    render(<FormLabel inputId="myId" isFieldRequired>my label</FormLabel>);
     const labelElement = screen.getByText('my label');
     expect(labelElement).toHaveTextContent('*');
   });
 
   test('Label correctly renders with error class if field has eror', () => {
-    render(<FormLabel inputId="myId" labelText="my label" hasError />);
+    render(<FormLabel inputId="myId" hasError>my label</FormLabel>);
     const labelElement = screen.getByText('my label');
     expect(labelElement.getAttribute('class')).toContain('error');
   });
 
   test('correctly assigns an id when given an inputId', () => {
-    render(<FormLabel inputId="myId" labelText="my label" hasError />);
+    render(<FormLabel inputId="myId" hasError>my label</FormLabel>);
     const labelElement = screen.getByText('my label');
     expect(labelElement).toHaveAttribute('id', 'myIdLabel');
   });

--- a/src/components/FormLabel/FormLabel.tsx
+++ b/src/components/FormLabel/FormLabel.tsx
@@ -1,16 +1,16 @@
-import React, { FC } from 'react';
+import React, { FC, ReactNode } from 'react';
 import classNames from 'classnames';
 import styles from './FormLabel.module.scss';
 
-interface Props {
+interface FormLabelProps {
   /**
    * The id of the form control that the label is labeling
    */
   inputId: string;
   /**
-   * The label text
+   * Content to be rendered inside the label.
    */
-  labelText: React.ReactNode;
+  children: ReactNode;
   /**
    * Custom class to pass to label element.
    */
@@ -37,9 +37,9 @@ interface Props {
   isRadioInputLabel?: boolean;
 }
 
-const FormLabel: FC<Props> = ({
+const FormLabel: FC<FormLabelProps> = ({
   inputId,
-  labelText,
+  children,
   className = '',
   displayInline = false,
   hasError = false,
@@ -65,7 +65,7 @@ const FormLabel: FC<Props> = ({
       className={labelClasses}
       htmlFor={inputId}
     >
-      {labelText}
+      {children}
       {isFieldRequired && <span>&nbsp;*</span>}
     </label>
   );

--- a/src/components/RadioGroup/RadioInput/RadioInput.tsx
+++ b/src/components/RadioGroup/RadioInput/RadioInput.tsx
@@ -65,14 +65,13 @@ const RadioInput: FC<Props> = ({
     if (onBlur) onBlur(event);
   };
 
-  const generateLabelProps = () => ({
+  const labelProps = {
     inputId: option.id,
-    labelText: option.label,
     isDisabled,
     displayInline: true,
     hasError: !!error,
     isRadioInputLabel: true,
-  });
+  };
 
   return (
     <>
@@ -90,7 +89,7 @@ const RadioInput: FC<Props> = ({
             onBlur={handleBlur}
             disabled={isDisabled}
           />
-          {option.label && <FormLabel {...generateLabelProps()} />}
+          {option.label && <FormLabel {...labelProps}>{option.label}</FormLabel>}
         </div>
       )}
     </>

--- a/src/components/SelectInput/SelectInput.tsx
+++ b/src/components/SelectInput/SelectInput.tsx
@@ -139,7 +139,6 @@ const SelectInput: FC<Props> = ({
   const labelProps = {
     isFieldRequired: isRequired,
     inputId: id,
-    labelText: label,
     hasError: !!error,
     className: styles['select-input-label'],
     isDisabled,
@@ -147,7 +146,7 @@ const SelectInput: FC<Props> = ({
 
   return (
     <div className={wrapperClasses}>
-      {label && !hideLabel && <FormLabel {...labelProps} />}
+      {label && !hideLabel && <FormLabel {...labelProps}>{label}</FormLabel>}
       <Select
         inputId={id}
         aria-label={label}

--- a/src/components/TextInput/TextInput.jsx
+++ b/src/components/TextInput/TextInput.jsx
@@ -196,7 +196,6 @@ const TextInput = ({
   const labelProps = {
     isFieldRequired: isRequired,
     inputId: id,
-    labelText: label,
     hasError: !!error,
     className: styles['text-input-label'],
     isDisabled,
@@ -204,12 +203,12 @@ const TextInput = ({
 
   return (
     <div className={className}>
-      {label && !hideLabel && <FormLabel {...labelProps} />}
+      {label && !hideLabel && <FormLabel {...labelProps}>{label}</FormLabel>}
       {!inputMask ? (
         <input {...inputProps} />
       ) : (
-          <Cleave {...inputProps} options={getInputMask(inputMask, InputMasks)} />
-        )}
+        <Cleave {...inputProps} options={getInputMask(inputMask, InputMasks)} />
+      )}
       {error && error !== true && <InputValidationMessage>{error}</InputValidationMessage>}
     </div>
   );

--- a/src/components/TextInput/TextInput.stories.mdx
+++ b/src/components/TextInput/TextInput.stories.mdx
@@ -25,7 +25,7 @@ All that is required to render a basic version of the TextInput is a unique `id`
 <Preview>
   <Story name="Default">
     {() => {
-      const [value, setValue] = useState(null);
+      const [value, setValue] = useState('');
       return (
         <div style={{ height: '85px' }}>
           <TextInput
@@ -47,7 +47,7 @@ Use the `isRequired` prop to mark the input as required.
 <Preview>
   <Story name="Required">
     {() => {
-      const [value, setValue] = useState(null);
+      const [value, setValue] = useState('');
       return (
         <div style={{ height: '85px' }}>
           <TextInput
@@ -70,7 +70,7 @@ Use the `placeholder` prop to add a custom placeholder.
 <Preview>
   <Story name="Placeholder">
     {() => {
-      const [value, setValue] = useState(null);
+      const [value, setValue] = useState('');
       return (
         <div style={{ height: '85px' }}>
           <TextInput
@@ -93,7 +93,7 @@ Use the `autoFocus` prop to autofocus the input.
 <Preview>
   <Story name="Autofocus">
     {() => {
-      const [value, setValue] = useState(null);
+      const [value, setValue] = useState('');
       return (
         <div style={{ height: '85px' }}>
           <TextInput
@@ -116,7 +116,7 @@ Use the `hideLabel` prop to not render the label.
 <Preview>
   <Story name="Hidden Label">
     {() => {
-      const [value, setValue] = useState(null);
+      const [value, setValue] = useState('');
       return (
         <div style={{ height: '60px' }}>
           <TextInput
@@ -139,7 +139,7 @@ Use the `isDisabled` prop to mark the input as disabled.
 <Preview>
   <Story name="Disabled">
     {() => {
-      const [value, setValue] = useState(null);
+      const [value, setValue] = useState('');
       return (
         <div style={{ height: '85px' }}>
           <TextInput
@@ -185,7 +185,7 @@ Use the `isDisabled` prop to mark the input as disabled. Disabled inputs can hav
 <Preview>
   <Story name="Disabled with Placeholder">
     {() => {
-      const [value, setValue] = useState(null);
+      const [value, setValue] = useState('');
       return (
         <div style={{ height: '85px' }}>
           <TextInput
@@ -209,7 +209,7 @@ Use the `type` prop to mark the input type as "tel". Use the `inputMask` prop to
 <Preview>
   <Story name="With Phone Mask">
     {() => {
-      const [value, setValue] = useState(null);
+      const [value, setValue] = useState('');
       return (
         <div style={{ height: '85px' }}>
           <TextInput
@@ -233,7 +233,7 @@ Use the `type` prop to mark the input type as "tel". Use the `inputMask` prop to
 <Preview>
   <Story name="With Credit Card Mask">
     {() => {
-      const [value, setValue] = useState(null);
+      const [value, setValue] = useState('');
       return (
         <div style={{ height: '85px' }}>
           <TextInput
@@ -257,7 +257,7 @@ Use the `maxLength` prop to limit the number of characters that can be entered i
 <Preview>
   <Story name="Max Length">
     {() => {
-      const [value, setValue] = useState(null);
+      const [value, setValue] = useState('');
       return (
         <div style={{ height: '85px' }}>
           <TextInput
@@ -281,7 +281,7 @@ Use the `error` prop to mark the input as invalid. `error` accepts a `boolean`, 
 <Preview>
   <Story name="Required with Error">
     {() => {
-      const [value, setValue] = useState(null);
+      const [value, setValue] = useState('');
       return (
         <div style={{ height: '85px' }}>
           <TextInput
@@ -305,7 +305,7 @@ Pass a `string` or `node` to the `error` prop to render a validation message.
 <Preview>
   <Story name="Required with Error and Validation Message">
     {() => {
-      const [value, setValue] = useState(null);
+      const [value, setValue] = useState('');
       return (
         <div style={{ height: '85px' }}>
           <TextInput
@@ -329,7 +329,7 @@ An input does not need to be marked as required to render a validation message.
 <Preview>
   <Story name="Not Required with Error and Validation Message">
     {() => {
-      const [value, setValue] = useState(null);
+      const [value, setValue] = useState('');
       return (
         <div style={{ height: '85px' }}>
           <TextInput
@@ -350,7 +350,7 @@ An input does not need to be marked as required to render a validation message.
 <Preview>
   <Story name="Error with Hidden Label">
     {() => {
-      const [value, setValue] = useState(null);
+      const [value, setValue] = useState('');
       return (
         <div style={{ height: '60px' }}>
           <TextInput
@@ -374,7 +374,7 @@ Use the `className` prop to add a custom class, or classes to an input.
 <Preview>
   <Story name="Custom Classes">
     {() => {
-      const [value, setValue] = useState(null);
+      const [value, setValue] = useState('');
       return (
         <div style={{ height: '85px' }}>
           <TextInput


### PR DESCRIPTION
Refactored label component (and corresponding components that depend on it) to take children, rather than a `labelText' prop. The label prop on our inputs is still required to be a string for accessibility reasons.