### PR TITLE
feat: width and height tokens

### DIFF
--- a/src/docs/Height.stories.mdx
+++ b/src/docs/Height.stories.mdx
@@ -8,7 +8,9 @@ import { PALMETTO_HEIGHT_OPTIONS, PALMETTO_HEIGHT_VALUES } from '../lib/tokens';
 
 # Height
 
-Height tokens are defined in `rem`, which means they will scale when adjusting the root font size. Pixel values are calculated with a root font size of `16px`.
+Standard heights have been defined based on percentages or `rem`.
+
+Rem based values will scale when adjusting the root font size. Pixel values are calculated with a root font size of `16px`.
 
 <table>
   <thead>

--- a/src/docs/Height.stories.mdx
+++ b/src/docs/Height.stories.mdx
@@ -21,12 +21,12 @@ Height tokens are defined in `rem`, which means they will scale when adjusting t
     </tr>
   </thead>
   <tbody>
-    {PALMETTO_HEIGHT_OPTIONS.map((space, i) => (
+    {PALMETTO_HEIGHT_OPTIONS.map((height, i) => (
       <tr key={i}>
-        <td><code>{`size-height-${space}`}</code></td>
-        <td><code>{space}</code></td>
+        <td><code>{`size-height-${height}`}</code></td>
+        <td><code>{height}</code></td>
         <td>{PALMETTO_HEIGHT_VALUES[i].value}</td>
-        <td>{space === 'base' ? '16' : PALMETTO_HEIGHT_VALUES[i].original.value * 16}</td>
+        <td>{height === 'base' ? '16' : PALMETTO_HEIGHT_VALUES[i].value.includes('%') ? '' : PALMETTO_HEIGHT_VALUES[i].original.value * 16}</td>
         <td>{PALMETTO_HEIGHT_VALUES[i].original.comment}</td>
       </tr>
     ))}

--- a/src/docs/Height.stories.mdx
+++ b/src/docs/Height.stories.mdx
@@ -3,7 +3,7 @@ import sizes from '@palmetto/palmetto-design-tokens/build/js/variables-size';
 import { PALMETTO_HEIGHT_OPTIONS, PALMETTO_HEIGHT_VALUES } from '../lib/tokens';
 
 <Meta
-  title="Design Tokens/Dimensions/Height"
+  title="Design Tokens/Height"
 />
 
 # Height

--- a/src/docs/Height.stories.mdx
+++ b/src/docs/Height.stories.mdx
@@ -1,0 +1,35 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+import sizes from '@palmetto/palmetto-design-tokens/build/js/variables-size';
+import { PALMETTO_HEIGHT_OPTIONS, PALMETTO_HEIGHT_VALUES } from '../lib/tokens';
+
+<Meta
+  title="Design Tokens/Dimensions/Height"
+/>
+
+# Height
+
+Height tokens are defined in `rem`, which means they will scale when adjusting the root font size. Pixel values are calculated with a root font size of `16px`.
+
+<table>
+  <thead>
+    <tr>
+      <th>token name</th>
+      <th>prop value</th>
+      <th>value</th>
+      <th>px</th>
+      <th>notes</th>
+    </tr>
+  </thead>
+  <tbody>
+    {PALMETTO_HEIGHT_OPTIONS.map((space, i) => (
+      <tr key={i}>
+        <td><code>{`size-height-${space}`}</code></td>
+        <td><code>{space}</code></td>
+        <td>{PALMETTO_HEIGHT_VALUES[i].value}</td>
+        <td>{space === 'base' ? '16' : PALMETTO_HEIGHT_VALUES[i].original.value * 16}</td>
+        <td>{PALMETTO_HEIGHT_VALUES[i].original.comment}</td>
+      </tr>
+    ))}
+  </tbody>
+</table>
+

--- a/src/docs/Width.stories.mdx
+++ b/src/docs/Width.stories.mdx
@@ -1,0 +1,35 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+import sizes from '@palmetto/palmetto-design-tokens/build/js/variables-size';
+import { PALMETTO_WIDTH_OPTIONS, PALMETTO_WIDTH_VALUES } from '../lib/tokens';
+
+<Meta
+  title="Design Tokens/Dimensions/Width"
+/>
+
+# Width
+
+Width tokens are defined in `rem`, which means they will scale when adjusting the root font size. Pixel values are calculated with a root font size of `16px`.
+
+<table>
+  <thead>
+    <tr>
+      <th>token name</th>
+      <th>prop value</th>
+      <th>value</th>
+      <th>px</th>
+      <th>notes</th>
+    </tr>
+  </thead>
+  <tbody>
+    {PALMETTO_WIDTH_OPTIONS.map((space, i) => (
+      <tr key={i}>
+        <td><code>{`size-width-${space}`}</code></td>
+        <td><code>{space}</code></td>
+        <td>{PALMETTO_WIDTH_VALUES[i].value}</td>
+        <td>{space === 'base' ? '16' : PALMETTO_WIDTH_VALUES[i].original.value * 16}</td>
+        <td>{PALMETTO_WIDTH_VALUES[i].original.comment}</td>
+      </tr>
+    ))}
+  </tbody>
+</table>
+

--- a/src/docs/Width.stories.mdx
+++ b/src/docs/Width.stories.mdx
@@ -3,7 +3,7 @@ import sizes from '@palmetto/palmetto-design-tokens/build/js/variables-size';
 import { PALMETTO_WIDTH_OPTIONS, PALMETTO_WIDTH_VALUES } from '../lib/tokens';
 
 <Meta
-  title="Design Tokens/Dimensions/Width"
+  title="Design Tokens/Width"
 />
 
 # Width

--- a/src/docs/Width.stories.mdx
+++ b/src/docs/Width.stories.mdx
@@ -21,12 +21,12 @@ Width tokens are defined in `rem`, which means they will scale when adjusting th
     </tr>
   </thead>
   <tbody>
-    {PALMETTO_WIDTH_OPTIONS.map((space, i) => (
+    {PALMETTO_WIDTH_OPTIONS.map((width, i) => (
       <tr key={i}>
-        <td><code>{`size-width-${space}`}</code></td>
-        <td><code>{space}</code></td>
+        <td><code>{`size-width-${width}`}</code></td>
+        <td><code>{width}</code></td>
         <td>{PALMETTO_WIDTH_VALUES[i].value}</td>
-        <td>{space === 'base' ? '16' : PALMETTO_WIDTH_VALUES[i].original.value * 16}</td>
+        <td>{width === 'base' ? '16' : PALMETTO_WIDTH_VALUES[i].value.includes('%') ? '' : PALMETTO_WIDTH_VALUES[i].original.value * 16}</td>
         <td>{PALMETTO_WIDTH_VALUES[i].original.comment}</td>
       </tr>
     ))}

--- a/src/docs/Width.stories.mdx
+++ b/src/docs/Width.stories.mdx
@@ -8,7 +8,9 @@ import { PALMETTO_WIDTH_OPTIONS, PALMETTO_WIDTH_VALUES } from '../lib/tokens';
 
 # Width
 
-Width tokens are defined in `rem`, which means they will scale when adjusting the root font size. Pixel values are calculated with a root font size of `16px`.
+Standard widths have been defined based on percentages or `rem`.
+
+Rem based values will scale when adjusting the root font size. Pixel values are calculated with a root font size of `16px`.
 
 <table>
   <thead>

--- a/src/lib/tokens.ts
+++ b/src/lib/tokens.ts
@@ -76,3 +76,9 @@ export const PALMETTO_BRAND_COLOR_VALUES = colors.color.brand;
 
 export const PALMETTO_SPACING_OPTIONS = Object.keys(sizes.size.spacing);
 export const PALMETTO_SPACING_VALUES = Object.values(sizes.size.spacing);
+
+export const PALMETTO_WIDTH_OPTIONS = Object.keys(sizes.size.width);
+export const PALMETTO_WIDTH_VALUES = Object.values(sizes.size.width);
+
+export const PALMETTO_HEIGHT_OPTIONS = Object.keys(sizes.size.height);
+export const PALMETTO_HEIGHT_VALUES = Object.values(sizes.size.height);


### PR DESCRIPTION
Adds documentation of width and height tokens

<img width="812" alt="Screen Shot 2020-09-15 at 3 42 37 PM" src="https://user-images.githubusercontent.com/1447339/93272338-1b030c00-f76a-11ea-8062-e0c0de2bf547.png">
