### PR TITLE
feat(Box): add max width and height props

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@fortawesome/fontawesome-svg-core": "^1.2.30",
     "@fortawesome/free-solid-svg-icons": "^5.14.0",
     "@fortawesome/react-fontawesome": "^0.1.11",
-    "@palmetto/palmetto-design-tokens": "^0.6.1",
+    "@palmetto/palmetto-design-tokens": "^0.7.0",
     "@types/cleave.js": "^1.4.3",
     "react-select": "^3.1.0"
   },

--- a/src/components/Box/Box.stories.mdx
+++ b/src/components/Box/Box.stories.mdx
@@ -618,7 +618,7 @@ Set the `radius` prop with a [radius token](/?path=/docs/design-tokens-border-ra
 
 ## Width
 
-Width can be set to any standard CSS value (px, rem, em, %).
+Width can be set to any CSS unit value (px, rem, em, %).
 
 <Canvas>
   <Story name="width">
@@ -630,7 +630,7 @@ Width can be set to any standard CSS value (px, rem, em, %).
   </Story>
 </Canvas>
 
-Standard widths are available at `sm` - `5xl`.
+[Width tokens](/?path=/docs/design-tokens-width--page) may be used to set widths as well.
 
 <Canvas>
   <Story name="width standards">
@@ -672,9 +672,23 @@ Set the width to a common percentage of the Box's parent.
   </Story>
 </Canvas>
 
+## Max Width
+
+Set the maximum width of the Box by setting `maxWidth` to a [width token](/?path=/docs/design-tokens-width--page) or any valid css unit.
+
+<Canvas>
+  <Story name="max width">
+    <Box background="primary-lightest" childGap="xs">
+      <Box background="primary-light" maxWidth="2xl">2xl</Box>
+      <Box background="primary-light" maxWidth="145px">145px</Box>
+      <Box background="primary-light" maxWidth="50%">50%</Box>
+    </Box>
+  </Story>
+</Canvas>
+
 ## Height
 
-Width can be set to any standard CSS value (px, rem, em, %).
+Height can be set to any CSS unit value (px, rem, em, %).
 
 <Canvas>
   <Story name="height">
@@ -686,7 +700,7 @@ Width can be set to any standard CSS value (px, rem, em, %).
   </Story>
 </Canvas>
 
-Standard heights are available at `sm` - `5xl`.
+[Width tokens](/?path=/docs/design-tokens-height--page) may be used to set height as well.
 
 <Canvas>
   <Story name="height standards">
@@ -702,7 +716,6 @@ Standard heights are available at `sm` - `5xl`.
     </Box>
   </Story>
 </Canvas>
-
 
 Set the height to a common percentage of the Box's parent.
 
@@ -728,6 +741,19 @@ Set the height to a common percentage of the Box's parent.
   </Story>
 </Canvas>
 
+## Max Height
+
+Set the maximum width of the Box by setting `maxHeight` to a [height token](/?path=/docs/design-tokens-height--page) or any valid css unit.
+
+<Canvas>
+  <Story name="max height">
+    <Box height="300px" background="primary-lightest" direction="row" childGap="xs">
+      <Box maxHeight="lg" flex="auto" justify="center" align="center" background="primary-light">lg</Box>
+      <Box maxHeight="50px" flex="auto" justify="center" align="center" background="primary-light">50px</Box>
+      <Box maxHeight="50%" flex="auto" justify="center" align="center" background="primary-light">50%</Box>
+    </Box>
+  </Story>
+</Canvas>
 
 ### Overflow
 

--- a/src/components/Box/Box.tsx
+++ b/src/components/Box/Box.tsx
@@ -122,6 +122,16 @@ interface BoxProps {
    */
   margin?: PALMETTO_SPACING;
   /**
+   * The maximum height of the element. Can be given a standard css value (px, rem, em, %),
+   * or a [height token](/?path=/docs/design-tokens-height--page)
+   */
+  maxHeight?: string;
+  /**
+   * The maximum width of the element. Can be given a standard css value (px, rem, em, %),
+   * or a [width token](/?path=/docs/design-tokens-width--page)
+   */
+  maxWidth?: string;
+  /**
    * The overflow property is specified as one or two keywords.
    * If two keywords are specified, the first applies to overflow-x and the second to overflow-y.
    * Otherwise, both overflow-x and overflow-y are set to the same value.
@@ -179,6 +189,8 @@ const Box: FC<BoxProps> = ({
   height = undefined,
   justify,
   margin,
+  maxHeight,
+  maxWidth,
   overflow = 'initial',
   padding = undefined,
   radius = undefined,
@@ -190,6 +202,8 @@ const Box: FC<BoxProps> = ({
   const paddingCss = getSpacingCss('p', padding);
   const heightCss = getDimensionCss('h', height);
   const widthCss = getDimensionCss('w', width);
+  const maxHeightCss = getDimensionCss('mh', maxHeight);
+  const maxWidthCss = getDimensionCss('mw', maxWidth);
   const flexCss = getFlexCss(flex);
 
   const wrapClass = wrap ? 'flex-wrap' : 'flex-nowrap';
@@ -201,6 +215,8 @@ const Box: FC<BoxProps> = ({
     marginCss.classes,
     paddingCss.classes,
     heightCss.classes,
+    maxHeightCss.classes,
+    maxWidthCss.classes,
     widthCss.classes,
     flexCss.classes,
     {
@@ -221,6 +237,8 @@ const Box: FC<BoxProps> = ({
   const boxStyles = {
     ...marginCss.styles,
     ...heightCss.styles,
+    ...maxHeightCss.styles,
+    ...maxWidthCss.styles,
     ...widthCss.styles,
     ...flexCss.styles,
     ...border && { borderWidth: '1px', borderStyle: 'solid' },

--- a/src/docs/Height.stories.mdx
+++ b/src/docs/Height.stories.mdx
@@ -8,7 +8,7 @@ import { PALMETTO_HEIGHT_OPTIONS, PALMETTO_HEIGHT_VALUES } from '../lib/tokens';
 
 # Height
 
-Standard heights have been defined based on percentages or `rem`.
+Used for both height and maximum height, height tokens have been defined based on percentages or `rem`.
 
 Rem based values will scale when adjusting the root font size. Pixel values are calculated with a root font size of `16px`.
 

--- a/src/docs/Width.stories.mdx
+++ b/src/docs/Width.stories.mdx
@@ -8,7 +8,7 @@ import { PALMETTO_WIDTH_OPTIONS, PALMETTO_WIDTH_VALUES } from '../lib/tokens';
 
 # Width
 
-Standard widths have been defined based on percentages or `rem`.
+Used for both width and maximum width, width tokens are defined based on a percentage or `rem`.
 
 Rem based values will scale when adjusting the root font size. Pixel values are calculated with a root font size of `16px`.
 

--- a/src/lib/getDimensionCss.test.js
+++ b/src/lib/getDimensionCss.test.js
@@ -27,6 +27,28 @@ describe('getDimensionCss', () => {
     });
   });
 
+  test('returns expected css object if max width css value is passed', () => {
+    const spacingCss = getDimensionCss('mw', '20px');
+
+    expect(spacingCss).toEqual({
+      classes: [],
+      styles: {
+        maxWidth: '20px',
+      },
+    });
+  });
+
+  test('returns expected css object if max height css value is passed', () => {
+    const spacingCss = getDimensionCss('mh', '42rem');
+
+    expect(spacingCss).toEqual({
+      classes: [],
+      styles: {
+        maxHeight: '42rem',
+      },
+    });
+  });
+
   describe('width', () => {
     PALMETTO_WIDTH_OPTIONS.map(token => (
       test(`returns expected css object if ${token} width value is passed`, () => {
@@ -47,6 +69,32 @@ describe('getDimensionCss', () => {
 
         expect(spacingCss).toEqual({
           classes: [`h-${token}`],
+          styles: undefined,
+        });
+      })
+    ));
+  });
+
+  describe('max width', () => {
+    PALMETTO_WIDTH_OPTIONS.map(token => (
+      test(`returns expected css object if ${token} max width value is passed`, () => {
+        const spacingCss = getDimensionCss('mw', token);
+
+        expect(spacingCss).toEqual({
+          classes: [`mw-${token}`],
+          styles: undefined,
+        });
+      })
+    ));
+  });
+
+  describe('max height', () => {
+    PALMETTO_HEIGHT_OPTIONS.map(token => (
+      test(`returns expected css object if ${token} max height value is passed`, () => {
+        const spacingCss = getDimensionCss('mh', token);
+
+        expect(spacingCss).toEqual({
+          classes: [`mh-${token}`],
           styles: undefined,
         });
       })

--- a/src/lib/getDimensionCss.ts
+++ b/src/lib/getDimensionCss.ts
@@ -7,9 +7,20 @@ function getDimensionStyles(dimension: CssDimension, value?: string): { [key: st
   let styles;
   // value is a css unit so set its style property
   if (typeof value === 'string' && doesStringIncludeCssUnit(value)) {
-    styles = dimension === 'w' ? { width: value } : { height: value };
+    switch (dimension) {
+      case 'h':
+        styles = { height: value };
+        break;
+      case 'mw':
+        styles = { maxWidth: value };
+        break;
+      case 'mh':
+        styles = { maxHeight: value };
+        break;
+      default:
+        styles = { width: value };
+    }
   }
-
   return styles;
 }
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -19,9 +19,7 @@ export interface FlexStylesAndClasses {
   classes?: string[];
 }
 
-export type CssDimension =
-  'h' |
-  'w';
+export type CssDimension = 'h' | 'w' | 'mw' | 'mh';
 
 export type CssSpacing =
   'm' |

--- a/yarn.lock
+++ b/yarn.lock
@@ -3017,10 +3017,10 @@
   dependencies:
     "@types/node" ">= 8"
 
-"@palmetto/palmetto-design-tokens@^0.6.1":
-  version "0.6.1"
-  resolved "https://registry.yarnpkg.com/@palmetto/palmetto-design-tokens/-/palmetto-design-tokens-0.6.1.tgz#a072ee54c736939c3e906ab419e23e7882687f3f"
-  integrity sha512-65l/yQMYGSH8/GhTySAY3zZceurtHZoc964iER0KAEiQYnhcnzMCuI5IDrghv+SzXJWgmP+k3crlumyz6pssgg==
+"@palmetto/palmetto-design-tokens@^0.7.0":
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/@palmetto/palmetto-design-tokens/-/palmetto-design-tokens-0.7.0.tgz#6eb0e1aa8d105d21d3f1bde9b5de2cdc8ea5f373"
+  integrity sha512-D2sXXnKFpzfGeM+QUvdMWslEcp0tcmKYz54Xj/pWT6wR27SjoomfEtbwFBWKk0WayOcpy1eqicgk7P7OgIoTCw==
 
 "@reach/router@^1.3.3":
   version "1.3.4"


### PR DESCRIPTION
behaves the same as existing `width` and `height` props, except sets max width and height for the box.

<img width="1037" alt="Screen Shot 2020-09-19 at 9 46 54 AM" src="https://user-images.githubusercontent.com/1447339/93672095-19cd2a00-fa5d-11ea-8eac-e17969211117.png">
<img width="1030" alt="Screen Shot 2020-09-19 at 9 47 07 AM" src="https://user-images.githubusercontent.com/1447339/93672097-1b96ed80-fa5d-11ea-87d1-8d15fe25804c.png">
