### PR TITLE
fix(Button): darken light outline font color

### DIFF
--- a/src/styles/variables/buttons.scss
+++ b/src/styles/variables/buttons.scss
@@ -63,7 +63,7 @@
 
   --button-border-color-light-outline: var(--color-brand-light-base);
   --button-background-color-light-outline: transparent;
-  --button-font-color-light-outline: var(--color-brand-light-base);
+  --button-font-color-light-outline: var(--color-brand-dark-base);
   --button-border-hover-color-light-outline: var(--color-brand-light-base);
   --button-background-hover-color-light-outline: var(--color-brand-light-base);
   --button-font-hover-color-light-outline: var(--color-brand-dark-base);


### PR DESCRIPTION
Before
<img width="502" alt="Screen Shot 2020-09-28 at 8 21 55 AM" src="https://user-images.githubusercontent.com/1447339/94451797-ae254400-0163-11eb-9d52-184aa96b3f8b.png">


After
<img width="492" alt="Screen Shot 2020-09-28 at 8 21 24 AM" src="https://user-images.githubusercontent.com/1447339/94451744-9f3e9180-0163-11eb-8a0a-4dfaa1d36386.png">
