### PR TITLE
fix: make SelectInput and TextInput take up 100% parent width

### DIFF
--- a/src/components/SelectInput/SelectInput.tsx
+++ b/src/components/SelectInput/SelectInput.tsx
@@ -9,6 +9,7 @@ import Select, {
 } from 'react-select';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faTimes } from '@fortawesome/free-solid-svg-icons';
+import Box from '../Box/Box';
 import FormLabel from '../FormLabel/FormLabel';
 import InputValidationMessage from '../InputValidationMessage/InputValidationMessage';
 import styles from './SelectInput.module.scss';
@@ -18,7 +19,7 @@ type SimulatedEventPayloadType = {
     name: string;
     value: ValueType<OptionTypeBase>;
   };
-}
+};
 
 interface SelectInputProps {
   /**
@@ -133,16 +134,11 @@ const SelectInput: FC<SelectInputProps> = ({
     if (onBlur) onBlur(e);
   };
 
-  const wrapperClasses = classNames(
-    'select-input-wrapper',
-    className,
-    { [styles.disabled]: isDisabled },
-  );
+  const wrapperClasses = classNames('select-input-wrapper', className, {
+    [styles.disabled]: isDisabled,
+  });
 
-  const inputClasses = classNames(
-    'react-select',
-    { [styles.error]: error },
-  );
+  const inputClasses = classNames('react-select', { [styles.error]: error });
 
   const labelProps = {
     isFieldRequired: isRequired,
@@ -159,7 +155,7 @@ const SelectInput: FC<SelectInputProps> = ({
   );
 
   return (
-    <div className={wrapperClasses}>
+    <Box width="100%" className={wrapperClasses}>
       {label && !hideLabel && <FormLabel {...labelProps}>{label}</FormLabel>}
       <Select
         inputId={id}
@@ -180,8 +176,10 @@ const SelectInput: FC<SelectInputProps> = ({
         onBlur={handleBlur}
         value={value}
       />
-      {error && typeof error !== 'boolean' && <InputValidationMessage>{error}</InputValidationMessage>}
-    </div>
+      {error && typeof error !== 'boolean' && (
+        <InputValidationMessage>{error}</InputValidationMessage>
+      )}
+    </Box>
   );
 };
 

--- a/src/components/TextInput/TextInput.stories.mdx
+++ b/src/components/TextInput/TextInput.stories.mdx
@@ -27,7 +27,7 @@ All that is required to render a basic version of the TextInput is a unique `id`
           id="default"
           value={value}
           label="Label"
-          onChange={(event) => setValue(event.target.value)}
+          onChange={event => setValue(event.target.value)}
         />
       );
     }}
@@ -47,7 +47,7 @@ Use the `isRequired` prop to mark the input as required.
           id="required"
           value={value}
           label="Label"
-          onChange={(event) => setValue(event.target.value)}
+          onChange={event => setValue(event.target.value)}
           isRequired
         />
       );
@@ -68,7 +68,7 @@ Use the `placeholder` prop to add a custom placeholder.
           id="placeholder"
           value={value}
           label="Label"
-          onChange={(event) => setValue(event.target.value)}
+          onChange={event => setValue(event.target.value)}
           placeholder="Custom placeholder..."
         />
       );
@@ -89,7 +89,7 @@ Use the `autoFocus` prop to autofocus the input.
           id="autofocus"
           value={value}
           label="Label"
-          onChange={(event) => setValue(event.target.value)}
+          onChange={event => setValue(event.target.value)}
           autoFocus
         />
       );
@@ -110,7 +110,7 @@ Use the `hideLabel` prop to not render the label.
           id="hiddenLabel"
           value={value}
           label="Label"
-          onChange={(event) => setValue(event.target.value)}
+          onChange={event => setValue(event.target.value)}
           hideLabel
         />
       );
@@ -131,7 +131,7 @@ Use the `isDisabled` prop to mark the input as disabled.
           id="disabled"
           value={value}
           label="Label"
-          onChange={(event) => setValue(event.target.value)}
+          onChange={event => setValue(event.target.value)}
           isDisabled
         />
       );
@@ -152,7 +152,7 @@ Use the `isDisabled` prop to mark the input as disabled. Disabled inputs can hav
           id="disabledWithValue"
           value={value}
           label="Label"
-          onChange={(event) => setValue(event.target.value)}
+          onChange={event => setValue(event.target.value)}
           isDisabled
         />
       );
@@ -173,7 +173,7 @@ Use the `isDisabled` prop to mark the input as disabled. Disabled inputs can hav
           id="disabledWithPlaceholder"
           value={value}
           label="Label"
-          onChange={(event) => setValue(event.target.value)}
+          onChange={event => setValue(event.target.value)}
           isDisabled
           placeholder="Useful placeholder..."
         />
@@ -196,8 +196,8 @@ a callback function when the clear icon is clicked, which can then be handled to
           id="required"
           value={value}
           label="Label"
-          onChange={(event) => setValue(event.target.value)}
-          onClear={(event) => setValue('')}
+          onChange={event => setValue(event.target.value)}
+          onClear={event => setValue('')}
           isRequired
         />
       );
@@ -218,7 +218,7 @@ Use the `type` prop to mark the input type as "tel". Use the `inputMask` prop to
           id="withPhoneMask"
           value={value}
           label="Label"
-          onChange={(event) => setValue(event.target.value)}
+          onChange={event => setValue(event.target.value)}
           type="tel"
           inputMask="phone"
         />
@@ -240,7 +240,7 @@ Use the `type` prop to mark the input type as "tel". Use the `inputMask` prop to
           id="withCreditCardMask"
           value={value}
           label="Label"
-          onChange={(event) => setValue(event.target.value)}
+          onChange={event => setValue(event.target.value)}
           type="tel"
           inputMask="creditCard"
         />
@@ -263,7 +263,7 @@ Use the `maxLength` prop to limit the number of characters that can be entered i
           value={value}
           label="Label"
           maxLength="5"
-          onChange={(event) => setValue(event.target.value)}
+          onChange={event => setValue(event.target.value)}
           placeholder="Can't enter more than 5 characters..."
         />
       );
@@ -284,7 +284,7 @@ Use the `error` prop to mark the input as invalid. `error` accepts a `boolean`, 
           id="requiredWithError"
           value={value}
           label="Label"
-          onChange={(event) => setValue(event.target.value)}
+          onChange={event => setValue(event.target.value)}
           error={true}
           isRequired
         />
@@ -306,7 +306,7 @@ Pass a `string` or `node` to the `error` prop to render a validation message.
           id="requiredWithValidationMessage"
           value={value}
           label="Label"
-          onChange={(event) => setValue(event.target.value)}
+          onChange={event => setValue(event.target.value)}
           isRequired
           error="Helpful validation message"
         />
@@ -328,7 +328,7 @@ An input does not need to be marked as required to render a validation message.
           id="notRequiredWithValidationMessage"
           value={value}
           label="Label"
-          onChange={(event) => setValue(event.target.value)}
+          onChange={event => setValue(event.target.value)}
           error="Helpful validation message"
         />
       );
@@ -348,7 +348,7 @@ An input does not need to be marked as required to render a validation message.
           value={value}
           label="Label"
           hideLabel
-          onChange={(event) => setValue(event.target.value)}
+          onChange={event => setValue(event.target.value)}
           error={true}
         />
       );
@@ -369,7 +369,7 @@ Use the `className` prop to add a custom class, or classes to an input.
           id="customClasses"
           value={value}
           label="Label"
-          onChange={(event) => setValue(event.target.value)}
+          onChange={event => setValue(event.target.value)}
           className="background-color-primary"
         />
       );
@@ -387,7 +387,7 @@ Use the `className` prop to add a custom class, or classes to an input.
         <Box
           direction={{
             base: 'column',
-            tablet: 'column',
+            tablet: 'row',
             desktop: 'row',
             hd: 'row',
           }}
@@ -402,17 +402,12 @@ Use the `className` prop to add a custom class, or classes to an input.
           <TextInput
             value={value1}
             label="input 1"
-            onChange={(event) => setValue1(event.target.value)}
+            onChange={event => setValue1(event.target.value)}
           />
           <TextInput
             value={value2}
             label="input 2"
-            onChange={(event) => setValue2(event.target.value)}
-          />
-          <TextInput
-            value={value3}
-            label="input 3"
-            onChange={(event) => setValue3(event.target.value)}
+            onChange={event => setValue2(event.target.value)}
           />
         </Box>
       );

--- a/src/components/TextInput/TextInput.stories.mdx
+++ b/src/components/TextInput/TextInput.stories.mdx
@@ -2,11 +2,9 @@ import { useState } from 'react';
 import { action } from '@storybook/addon-actions';
 import { Meta, Story, Canvas, ArgsTable } from '@storybook/addon-docs/blocks';
 import TextInput from './TextInput';
+import Box from '../Box/Box';
 
-<Meta
-  title="Components/Form Inputs/TextInput"
-  component={TextInput}
-/>
+<Meta title="Components/Form Inputs/TextInput" component={TextInput} />
 
 # TextInput
 
@@ -25,14 +23,12 @@ All that is required to render a basic version of the TextInput is a unique `id`
     {() => {
       const [value, setValue] = useState('');
       return (
-        <div style={{ height: '85px' }}>
-          <TextInput
-            id="default"
-            value={value}
-            label="Label"
-            onChange={event => setValue(event.target.value)}
-          />
-        </div>
+        <TextInput
+          id="default"
+          value={value}
+          label="Label"
+          onChange={(event) => setValue(event.target.value)}
+        />
       );
     }}
   </Story>
@@ -47,15 +43,13 @@ Use the `isRequired` prop to mark the input as required.
     {() => {
       const [value, setValue] = useState('');
       return (
-        <div style={{ height: '85px' }}>
-          <TextInput
-            id="required"
-            value={value}
-            label="Label"
-            onChange={event => setValue(event.target.value)}
-            isRequired
-          />
-        </div>
+        <TextInput
+          id="required"
+          value={value}
+          label="Label"
+          onChange={(event) => setValue(event.target.value)}
+          isRequired
+        />
       );
     }}
   </Story>
@@ -70,15 +64,13 @@ Use the `placeholder` prop to add a custom placeholder.
     {() => {
       const [value, setValue] = useState('');
       return (
-        <div style={{ height: '85px' }}>
-          <TextInput
-            id="placeholder"
-            value={value}
-            label="Label"
-            onChange={event => setValue(event.target.value)}
-            placeholder="Custom placeholder..."
-          />
-        </div>
+        <TextInput
+          id="placeholder"
+          value={value}
+          label="Label"
+          onChange={(event) => setValue(event.target.value)}
+          placeholder="Custom placeholder..."
+        />
       );
     }}
   </Story>
@@ -93,15 +85,13 @@ Use the `autoFocus` prop to autofocus the input.
     {() => {
       const [value, setValue] = useState('');
       return (
-        <div style={{ height: '85px' }}>
-          <TextInput
-            id="autofocus"
-            value={value}
-            label="Label"
-            onChange={event => setValue(event.target.value)}
-            autoFocus
-          />
-        </div>
+        <TextInput
+          id="autofocus"
+          value={value}
+          label="Label"
+          onChange={(event) => setValue(event.target.value)}
+          autoFocus
+        />
       );
     }}
   </Story>
@@ -116,15 +106,13 @@ Use the `hideLabel` prop to not render the label.
     {() => {
       const [value, setValue] = useState('');
       return (
-        <div style={{ height: '60px' }}>
-          <TextInput
-            id="hiddenLabel"
-            value={value}
-            label="Label"
-            onChange={event => setValue(event.target.value)}
-            hideLabel
-          />
-        </div>
+        <TextInput
+          id="hiddenLabel"
+          value={value}
+          label="Label"
+          onChange={(event) => setValue(event.target.value)}
+          hideLabel
+        />
       );
     }}
   </Story>
@@ -139,15 +127,13 @@ Use the `isDisabled` prop to mark the input as disabled.
     {() => {
       const [value, setValue] = useState('');
       return (
-        <div style={{ height: '85px' }}>
-          <TextInput
-            id="disabled"
-            value={value}
-            label="Label"
-            onChange={event => setValue(event.target.value)}
-            isDisabled
-          />
-        </div>
+        <TextInput
+          id="disabled"
+          value={value}
+          label="Label"
+          onChange={(event) => setValue(event.target.value)}
+          isDisabled
+        />
       );
     }}
   </Story>
@@ -162,15 +148,13 @@ Use the `isDisabled` prop to mark the input as disabled. Disabled inputs can hav
     {() => {
       const [value, setValue] = useState('Preset value');
       return (
-        <div style={{ height: '85px' }}>
-          <TextInput
-            id="disabledWithValue"
-            value={value}
-            label="Label"
-            onChange={event => setValue(event.target.value)}
-            isDisabled
-          />
-        </div>
+        <TextInput
+          id="disabledWithValue"
+          value={value}
+          label="Label"
+          onChange={(event) => setValue(event.target.value)}
+          isDisabled
+        />
       );
     }}
   </Story>
@@ -185,21 +169,18 @@ Use the `isDisabled` prop to mark the input as disabled. Disabled inputs can hav
     {() => {
       const [value, setValue] = useState('');
       return (
-        <div style={{ height: '85px' }}>
-          <TextInput
-            id="disabledWithPlaceholder"
-            value={value}
-            label="Label"
-            onChange={event => setValue(event.target.value)}
-            isDisabled
-            placeholder="Useful placeholder..."
-          />
-        </div>
+        <TextInput
+          id="disabledWithPlaceholder"
+          value={value}
+          label="Label"
+          onChange={(event) => setValue(event.target.value)}
+          isDisabled
+          placeholder="Useful placeholder..."
+        />
       );
     }}
   </Story>
 </Canvas>
-
 
 ## Clearable
 
@@ -211,16 +192,14 @@ a callback function when the clear icon is clicked, which can then be handled to
     {() => {
       const [value, setValue] = useState('clear me');
       return (
-        <div style={{ height: '85px' }}>
-          <TextInput
-            id="required"
-            value={value}
-            label="Label"
-            onChange={event => setValue(event.target.value)}
-            onClear={event => setValue('')}
-            isRequired
-          />
-        </div>
+        <TextInput
+          id="required"
+          value={value}
+          label="Label"
+          onChange={(event) => setValue(event.target.value)}
+          onClear={(event) => setValue('')}
+          isRequired
+        />
       );
     }}
   </Story>
@@ -235,16 +214,14 @@ Use the `type` prop to mark the input type as "tel". Use the `inputMask` prop to
     {() => {
       const [value, setValue] = useState('');
       return (
-        <div style={{ height: '85px' }}>
-          <TextInput
-            id="withPhoneMask"
-            value={value}
-            label="Label"
-            onChange={event => setValue(event.target.value)}
-            type="tel"
-            inputMask="phone"
-          />
-        </div>
+        <TextInput
+          id="withPhoneMask"
+          value={value}
+          label="Label"
+          onChange={(event) => setValue(event.target.value)}
+          type="tel"
+          inputMask="phone"
+        />
       );
     }}
   </Story>
@@ -259,16 +236,14 @@ Use the `type` prop to mark the input type as "tel". Use the `inputMask` prop to
     {() => {
       const [value, setValue] = useState('');
       return (
-        <div style={{ height: '85px' }}>
-          <TextInput
-            id="withCreditCardMask"
-            value={value}
-            label="Label"
-            onChange={event => setValue(event.target.value)}
-            type="tel"
-            inputMask="creditCard"
-          />
-        </div>
+        <TextInput
+          id="withCreditCardMask"
+          value={value}
+          label="Label"
+          onChange={(event) => setValue(event.target.value)}
+          type="tel"
+          inputMask="creditCard"
+        />
       );
     }}
   </Story>
@@ -283,16 +258,14 @@ Use the `maxLength` prop to limit the number of characters that can be entered i
     {() => {
       const [value, setValue] = useState('');
       return (
-        <div style={{ height: '85px' }}>
-          <TextInput
-            id="maxLength"
-            value={value}
-            label="Label"
-            maxLength="5"
-            onChange={event => setValue(event.target.value)}
-            placeholder="Can't enter more than 5 characters..."
-          />
-        </div>
+        <TextInput
+          id="maxLength"
+          value={value}
+          label="Label"
+          maxLength="5"
+          onChange={(event) => setValue(event.target.value)}
+          placeholder="Can't enter more than 5 characters..."
+        />
       );
     }}
   </Story>
@@ -307,16 +280,14 @@ Use the `error` prop to mark the input as invalid. `error` accepts a `boolean`, 
     {() => {
       const [value, setValue] = useState('');
       return (
-        <div style={{ height: '85px' }}>
-          <TextInput
-            id="requiredWithError"
-            value={value}
-            label="Label"
-            onChange={event => setValue(event.target.value)}
-            error={true}
-            isRequired
-          />
-        </div>
+        <TextInput
+          id="requiredWithError"
+          value={value}
+          label="Label"
+          onChange={(event) => setValue(event.target.value)}
+          error={true}
+          isRequired
+        />
       );
     }}
   </Story>
@@ -331,16 +302,14 @@ Pass a `string` or `node` to the `error` prop to render a validation message.
     {() => {
       const [value, setValue] = useState('');
       return (
-        <div style={{ height: '85px' }}>
-          <TextInput
-            id="requiredWithValidationMessage"
-            value={value}
-            label="Label"
-            onChange={event => setValue(event.target.value)}
-            isRequired
-            error="Helpful validation message"
-          />
-        </div>
+        <TextInput
+          id="requiredWithValidationMessage"
+          value={value}
+          label="Label"
+          onChange={(event) => setValue(event.target.value)}
+          isRequired
+          error="Helpful validation message"
+        />
       );
     }}
   </Story>
@@ -355,15 +324,13 @@ An input does not need to be marked as required to render a validation message.
     {() => {
       const [value, setValue] = useState('');
       return (
-        <div style={{ height: '85px' }}>
-          <TextInput
-            id="notRequiredWithValidationMessage"
-            value={value}
-            label="Label"
-            onChange={event => setValue(event.target.value)}
-            error="Helpful validation message"
-          />
-        </div>
+        <TextInput
+          id="notRequiredWithValidationMessage"
+          value={value}
+          label="Label"
+          onChange={(event) => setValue(event.target.value)}
+          error="Helpful validation message"
+        />
       );
     }}
   </Story>
@@ -376,16 +343,14 @@ An input does not need to be marked as required to render a validation message.
     {() => {
       const [value, setValue] = useState('');
       return (
-        <div style={{ height: '60px' }}>
-          <TextInput
-            id="errorWithHiddenLabel"
-            value={value}
-            label="Label"
-            hideLabel
-            onChange={event => setValue(event.target.value)}
-            error={true}
-          />
-        </div>
+        <TextInput
+          id="errorWithHiddenLabel"
+          value={value}
+          label="Label"
+          hideLabel
+          onChange={(event) => setValue(event.target.value)}
+          error={true}
+        />
       );
     }}
   </Story>
@@ -400,24 +365,57 @@ Use the `className` prop to add a custom class, or classes to an input.
     {() => {
       const [value, setValue] = useState('');
       return (
-        <div style={{ height: '85px' }}>
-          <TextInput
-            id="customClasses"
-            value={value}
-            label="Label"
-            onChange={event => setValue(event.target.value)}
-            className="background-color-primary"
-          />
-        </div>
+        <TextInput
+          id="customClasses"
+          value={value}
+          label="Label"
+          onChange={(event) => setValue(event.target.value)}
+          className="background-color-primary"
+        />
       );
     }}
   </Story>
 </Canvas>
 
-
-
-
-
-
-
-
+<Canvas>
+  <Story name="Adjacent Inputs">
+    {() => {
+      const [value1, setValue1] = useState('');
+      const [value2, setValue2] = useState('');
+      const [value3, setValue3] = useState('');
+      return (
+        <Box
+          direction={{
+            base: 'column',
+            tablet: 'column',
+            desktop: 'row',
+            hd: 'row',
+          }}
+          childGap={{
+            base: 'sm',
+            tablet: 'md',
+            desktop: 'lg',
+            hd: 'lg',
+          }}
+          width="100%"
+        >
+          <TextInput
+            value={value1}
+            label="input 1"
+            onChange={(event) => setValue1(event.target.value)}
+          />
+          <TextInput
+            value={value2}
+            label="input 2"
+            onChange={(event) => setValue2(event.target.value)}
+          />
+          <TextInput
+            value={value3}
+            label="input 3"
+            onChange={(event) => setValue3(event.target.value)}
+          />
+        </Box>
+      );
+    }}
+  </Story>
+</Canvas>

--- a/src/components/TextInput/TextInput.tsx
+++ b/src/components/TextInput/TextInput.tsx
@@ -12,6 +12,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faTimes } from '@fortawesome/free-solid-svg-icons';
 import { UnknownPropertiesObjType } from '../../lib/types';
 import * as InputMasks from './TextInputMasks';
+import Box from '../Box/Box';
 import FormLabel from '../FormLabel/FormLabel';
 import InputValidationMessage from '../InputValidationMessage/InputValidationMessage';
 import styles from './TextInput.module.scss';
@@ -35,7 +36,7 @@ interface TextInputProps {
    * The text value of the input. Required since our Input is a controlled component.
    */
   value: string;
-   /**
+  /**
    * The input's 'autocomplete' attribute.
    */
   autoComplete?: boolean | string;
@@ -87,7 +88,9 @@ interface TextInputProps {
    * Callback function to call when input us cleared. When this is passed,
    * the input will display an icon on the right side, for triggering this callback.
    */
-  onClear?: (event: (MouseEvent<HTMLButtonElement> | KeyboardEvent<HTMLButtonElement>)) => void;
+  onClear?: (
+    event: MouseEvent<HTMLButtonElement> | KeyboardEvent<HTMLButtonElement>,
+  ) => void;
   /**
    * Callback function to call on focus event.
    */
@@ -145,8 +148,9 @@ const TextInput: FC<TextInputProps> = ({
 
   const getAutoCompleteValue = () => {
     if (
-      !autoComplete
-      || (typeof autoComplete !== 'boolean' && typeof autoComplete !== 'string')) {
+      !autoComplete ||
+      (typeof autoComplete !== 'boolean' && typeof autoComplete !== 'string')
+    ) {
       return 'off';
     }
 
@@ -157,13 +161,10 @@ const TextInput: FC<TextInputProps> = ({
     return autoComplete;
   };
 
-  const inputWrapperClasses = classNames(
-    styles['text-input-wrapper'],
-    {
-      [styles.error]: error,
-      [styles.disabled]: isDisabled,
-    },
-  );
+  const inputWrapperClasses = classNames(styles['text-input-wrapper'], {
+    [styles.error]: error,
+    [styles.disabled]: isDisabled,
+  });
 
   const renderClearIcon = (): ReactNode => {
     const handleKeyPress = (event: KeyboardEvent<HTMLButtonElement>): void => {
@@ -178,10 +179,7 @@ const TextInput: FC<TextInputProps> = ({
         className={styles['clear-button']}
         data-testid="text-input-clear-button"
       >
-        <FontAwesomeIcon
-          icon={faTimes}
-          className={styles['clear-icon']}
-        />
+        <FontAwesomeIcon icon={faTimes} className={styles['clear-icon']} />
       </button>
     );
   };
@@ -214,18 +212,23 @@ const TextInput: FC<TextInputProps> = ({
   };
 
   return (
-    <div className={className}>
+    <Box width="100%" className={className}>
       {label && !hideLabel && <FormLabel {...labelProps}>{label}</FormLabel>}
       <div className={inputWrapperClasses}>
         {!inputMask ? (
           <input {...inputProps} />
         ) : (
-          <Cleave {...inputProps} options={getInputMask(inputMask, InputMasks)} />
+          <Cleave
+            {...inputProps}
+            options={getInputMask(inputMask, InputMasks)}
+          />
         )}
         {!!onClear && !!value && renderClearIcon()}
       </div>
-      {error && error !== true && <InputValidationMessage>{error}</InputValidationMessage>}
-    </div>
+      {error && error !== true && (
+        <InputValidationMessage>{error}</InputValidationMessage>
+      )}
+    </Box>
   );
 };
 

--- a/src/components/TextInput/TextInput.tsx
+++ b/src/components/TextInput/TextInput.tsx
@@ -148,8 +148,8 @@ const TextInput: FC<TextInputProps> = ({
 
   const getAutoCompleteValue = () => {
     if (
-      !autoComplete ||
-      (typeof autoComplete !== 'boolean' && typeof autoComplete !== 'string')
+      !autoComplete
+      || (typeof autoComplete !== 'boolean' && typeof autoComplete !== 'string')
     ) {
       return 'off';
     }


### PR DESCRIPTION
When rendering adjacent TextInputs, the TextInputs should take up 100% of the available width.

For example
```
<Box row="column" childGap="lg">
  <TextInput />
  <TextInput />
</Box>
```

Currently looks like this
![Screen Shot 2020-10-09 at 11 49 35 AM](https://user-images.githubusercontent.com/1447339/95620811-95e7db80-0a25-11eb-9b6f-97672467e32e.png)

This PR does this:
![Screen Shot 2020-10-09 at 11 48 40 AM](https://user-images.githubusercontent.com/1447339/95620832-9f714380-0a25-11eb-99bc-02ea5fd1895b.png)
