### PR TITLE
feat: Add help text to form inputs

### DIFF
--- a/src/components/CheckboxInput/CheckboxInput.module.scss
+++ b/src/components/CheckboxInput/CheckboxInput.module.scss
@@ -1,6 +1,6 @@
 .checkbox {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   line-height: var(--form-control-line-height);
 
   &.disabled {
@@ -15,5 +15,9 @@
     margin: 0 var(--size-spacing-sm) 0 0;
     width: var(--size-spacing-lg);
     height: var(--size-spacing-lg);
+  }
+
+  .checkbox-label {
+    margin-top: var(--size-spacing-2xs);
   }
 }

--- a/src/components/CheckboxInput/CheckboxInput.stories.mdx
+++ b/src/components/CheckboxInput/CheckboxInput.stories.mdx
@@ -71,7 +71,6 @@ Use the `helpText` prop to add clarifying text beneath the input label.
           helpText="More helpful text about this checkbox"
           isChecked={value}
           onChange={event => setValue(event.target.checked)}
-          isRequired
         />
       );
     }}

--- a/src/components/CheckboxInput/CheckboxInput.stories.mdx
+++ b/src/components/CheckboxInput/CheckboxInput.stories.mdx
@@ -2,12 +2,10 @@ import { useState } from 'react';
 import { action } from '@storybook/addon-actions';
 import { Meta, Story, Canvas, ArgsTable } from '@storybook/addon-docs/blocks';
 import CheckboxInput from './CheckboxInput';
+import Box from '../Box/Box';
 import FormLabel from '../FormLabel/FormLabel';
 
-<Meta
-  title="Components/Form Inputs/CheckboxInput"
-  component={CheckboxInput}
-/>
+<Meta title="Components/Form Inputs/CheckboxInput" component={CheckboxInput} />
 
 # CheckboxInput
 
@@ -49,6 +47,28 @@ Use the `isRequired` prop to mark the input as required.
         <CheckboxInput
           id="requiredCheckboxIsUnchecked"
           label="Label"
+          isChecked={value}
+          onChange={event => setValue(event.target.checked)}
+          isRequired
+        />
+      );
+    }}
+  </Story>
+</Canvas>
+
+## Help Text
+
+Use the `helpText` prop to add clarifying text beneath the input label.
+
+<Canvas>
+  <Story name="Help Text">
+    {() => {
+      const [value, setValue] = useState(null);
+      return (
+        <CheckboxInput
+          id="requiredCheckboxIsUnchecked"
+          label="Checkbox with help text"
+          helpText="More helpful text about this checkbox"
           isChecked={value}
           onChange={event => setValue(event.target.checked)}
           isRequired
@@ -111,21 +131,26 @@ and append your own. Feel free to use the `FormLabel` component to keep the base
     {() => {
       const [value, setValue] = useState(null);
       return (
-          <>
-            <CheckboxInput
-              id="customLabel"
-              label="This label is custom"
-              hideLabel
-              onChange={value => setValue(event.target.checked)}
-              isChecked={value}
-              displayInline
-            />
-            <div style={{ display: 'inline-flex', verticalAlign: 'super' }}>
-              <FormLabel inputId="customLabel">
-                This is custom, look at this <a href="https://palmetto.com" onClick={() => alert('hey you clicked me!')} target="_blank">Link</a>
-              </FormLabel>
-            </div>
-          </>
+        <Box direction="row" alignItems="center">
+          <CheckboxInput
+            id="customLabel"
+            label="This label is custom"
+            hideLabel
+            onChange={value => setValue(event.target.checked)}
+            isChecked={value}
+            displayInline
+          />
+          <FormLabel inputId="customLabel">
+            This is custom, look at this{' '}
+            <a
+              href="https://palmetto.com"
+              onClick={() => alert('hey you clicked me!')}
+              target="_blank"
+            >
+              Link
+            </a>
+          </FormLabel>
+        </Box>
       );
     }}
   </Story>

--- a/src/components/CheckboxInput/CheckboxInput.test.jsx
+++ b/src/components/CheckboxInput/CheckboxInput.test.jsx
@@ -40,6 +40,7 @@ describe('CheckboxInput', () => {
         label="test checkbox"
         onChange={() => null}
         isChecked={false}
+        helpText="i am help text"
       />,
     );
     expect(getByLabelText('test checkbox')).toBeDefined();
@@ -47,9 +48,10 @@ describe('CheckboxInput', () => {
     expect(FormLabel).toHaveBeenCalledWith({
       inputId: 'testCheckbox',
       hasError: false,
+      helpText: 'i am help text',
       isFieldRequired: false,
       children: 'test checkbox',
-      className: undefined,
+      className: 'checkbox-label',
       isDisabled: false,
     }, {});
   });
@@ -69,9 +71,10 @@ describe('CheckboxInput', () => {
     expect(FormLabel).toHaveBeenCalledWith({
       inputId: 'testCheckbox',
       hasError: false,
+      helpText: undefined,
       isFieldRequired: true,
       children: 'test checkbox',
-      className: undefined,
+      className: 'checkbox-label',
       isDisabled: false,
     }, {});
   });
@@ -142,9 +145,10 @@ describe('CheckboxInput', () => {
       expect(FormLabel).toHaveBeenCalledWith({
         inputId: 'testCheckbox',
         hasError: true,
+        helpText: undefined,
         isFieldRequired: false,
         children: 'test checkbox',
-        className: undefined,
+        className: 'checkbox-label',
         isDisabled: false,
       }, {});
     });
@@ -163,9 +167,10 @@ describe('CheckboxInput', () => {
       expect(FormLabel).toHaveBeenCalledWith({
         inputId: 'testCheckbox',
         hasError: true,
+        helpText: undefined,
         isFieldRequired: false,
         children: 'test checkbox',
-        className: undefined,
+        className: 'checkbox-label',
         isDisabled: false,
       }, {});
     });
@@ -185,9 +190,10 @@ describe('CheckboxInput', () => {
     expect(FormLabel).toHaveBeenCalledWith({
       inputId: 'testCheckbox',
       hasError: false,
+      helpText: undefined,
       isFieldRequired: false,
       children: 'test checkbox',
-      className: undefined,
+      className: 'checkbox-label',
       isDisabled: true,
     }, {});
   });

--- a/src/components/CheckboxInput/CheckboxInput.tsx
+++ b/src/components/CheckboxInput/CheckboxInput.tsx
@@ -7,6 +7,7 @@ import React, {
 import classNames from 'classnames';
 import InputValidationMessage from '../InputValidationMessage/InputValidationMessage';
 import FormLabel from '../FormLabel/FormLabel';
+import Box from '../Box/Box';
 import styles from './CheckboxInput.module.scss';
 
 interface CheckboxInputProps {
@@ -40,6 +41,10 @@ interface CheckboxInputProps {
    */
   error?: ReactNode;
   /**
+   * Additional clarifying text to help describe the input
+   */
+  helpText?: ReactNode;
+  /**
    * Determines if the label is not shown for stylistic reasons.
    * Note the label is still a required prop and will be used as the aria-label for accessibility reasons.
    */
@@ -71,6 +76,7 @@ const CheckboxInput: FC<CheckboxInputProps> = ({
   displayInline = false,
   error = false,
   hideLabel = false,
+  helpText,
   isDisabled = false,
   isRequired = false,
   onBlur = undefined,
@@ -111,13 +117,15 @@ const CheckboxInput: FC<CheckboxInputProps> = ({
 
   const labelProps = {
     isFieldRequired: isRequired,
+    className: styles['checkbox-label'],
     inputId: id,
     hasError: !!error,
+    helpText,
     isDisabled,
   };
 
   return (
-    <>
+    <Box className={className}>
       <div className={wrapperClasses}>
         <input {...inputProps} />
         {label && !hideLabel && (
@@ -127,7 +135,7 @@ const CheckboxInput: FC<CheckboxInputProps> = ({
         )}
       </div>
       {error && error !== true && <InputValidationMessage>{error}</InputValidationMessage>}
-    </>
+    </Box>
   );
 };
 

--- a/src/components/CheckboxInput/CheckboxInput.tsx
+++ b/src/components/CheckboxInput/CheckboxInput.tsx
@@ -127,7 +127,9 @@ const CheckboxInput: FC<CheckboxInputProps> = ({
   return (
     <Box className={className}>
       <div className={wrapperClasses}>
-        <input {...inputProps} />
+        <div>
+          <input {...inputProps} />
+        </div>
         {label && !hideLabel && (
           <FormLabel {...labelProps}>
             {label}

--- a/src/components/CheckboxInput/CheckboxInput.tsx
+++ b/src/components/CheckboxInput/CheckboxInput.tsx
@@ -124,7 +124,7 @@ const CheckboxInput: FC<CheckboxInputProps> = ({
   };
 
   return (
-    <Box className={wrapperClasses}>
+    <Box className={className}>
       <div className={wrapperClasses}>
         <div>
           <input {...inputProps} />

--- a/src/components/CheckboxInput/CheckboxInput.tsx
+++ b/src/components/CheckboxInput/CheckboxInput.tsx
@@ -96,7 +96,6 @@ const CheckboxInput: FC<CheckboxInputProps> = ({
 
   const wrapperClasses = classNames(
     styles.checkbox,
-    className,
     { [styles.disabled]: isDisabled },
     { [styles.inline]: displayInline },
   );
@@ -125,7 +124,7 @@ const CheckboxInput: FC<CheckboxInputProps> = ({
   };
 
   return (
-    <Box className={className}>
+    <Box className={wrapperClasses}>
       <div className={wrapperClasses}>
         <div>
           <input {...inputProps} />

--- a/src/components/FormLabel/FormLabel.module.scss
+++ b/src/components/FormLabel/FormLabel.module.scss
@@ -25,4 +25,9 @@
       color: var(--color-brand-danger-lighter);
     }
   }
+
+  .help-text {
+    margin-top: var(--form-control-help-margin);
+    font-weight: 400;
+  }
 }

--- a/src/components/FormLabel/FormLabel.test.jsx
+++ b/src/components/FormLabel/FormLabel.test.jsx
@@ -35,4 +35,9 @@ describe('FormLabel', () => {
     const labelElement = screen.getByText('my label');
     expect(labelElement).toHaveAttribute('id', 'myIdLabel');
   });
+
+  test('renders help text if provided', () => {
+    const { getByText } = render(<FormLabel inputId="myId" helpText="i am help text">my label</FormLabel>);
+    expect(getByText('i am help text')).toBeDefined();
+  });
 });

--- a/src/components/FormLabel/FormLabel.tsx
+++ b/src/components/FormLabel/FormLabel.tsx
@@ -66,7 +66,7 @@ const FormLabel: FC<FormLabelProps> = ({
       {children}
       {isFieldRequired && <span>&nbsp;*</span>}
       {helpText && (
-        <Box as="p" fontSize="sm" color="grey" className={styles['help-text']}>
+        <Box as="p" display="block" fontSize="sm" color="grey" className={styles['help-text']}>
           {helpText}
         </Box>
       )}

--- a/src/components/FormLabel/FormLabel.tsx
+++ b/src/components/FormLabel/FormLabel.tsx
@@ -1,5 +1,6 @@
 import React, { FC, ReactNode } from 'react';
 import classNames from 'classnames';
+import Box from '../Box/Box';
 import styles from './FormLabel.module.scss';
 
 interface FormLabelProps {
@@ -24,6 +25,10 @@ interface FormLabelProps {
    */
   hasError?: boolean;
   /**
+   * Additional clarifying text to that helps describe the field
+   */
+  helpText?: ReactNode;
+  /**
    * Mark the label has disabled
    */
   isDisabled?: boolean;
@@ -43,30 +48,28 @@ const FormLabel: FC<FormLabelProps> = ({
   className = '',
   displayInline = false,
   hasError = false,
+  helpText,
   isDisabled = false,
   isFieldRequired = false,
   isRadioInputLabel = false,
 }) => {
-  const labelClasses = classNames(
-    styles.label,
-    className,
-    {
-      [styles.disabled]: isDisabled,
-      [styles.error]: hasError,
-      [styles.disabled]: isDisabled,
-      [styles.inline]: displayInline,
-      [styles['radio-input-label']]: isRadioInputLabel,
-    },
-  );
+  const labelClasses = classNames(styles.label, className, {
+    [styles.disabled]: isDisabled,
+    [styles.error]: hasError,
+    [styles.disabled]: isDisabled,
+    [styles.inline]: displayInline,
+    [styles['radio-input-label']]: isRadioInputLabel,
+  });
 
   return (
-    <label
-      id={`${inputId}Label`}
-      className={labelClasses}
-      htmlFor={inputId}
-    >
+    <label id={`${inputId}Label`} className={labelClasses} htmlFor={inputId}>
       {children}
       {isFieldRequired && <span>&nbsp;*</span>}
+      {helpText && (
+        <Box as="p" fontSize="sm" color="grey" className={styles['help-text']}>
+          {helpText}
+        </Box>
+      )}
     </label>
   );
 };

--- a/src/components/SelectInput/SelectInput.stories.mdx
+++ b/src/components/SelectInput/SelectInput.stories.mdx
@@ -72,6 +72,36 @@ Pre-select an option by passing its value to the `value` prop.
   </Story>
 </Canvas>
 
+## Help Text
+
+Use the `helpText` prop to add clarifying text beneath the input label.
+
+<Canvas> 
+  <Story name="Help Text">
+    {() => {
+      const [value, setValue] = useState(null);
+      const options = [
+        { value: 'chocolate', label: 'Chocolate' },
+        { value: 'strawberry', label: 'Strawberry' },
+        { value: 'vanilla', label: 'Vanilla' },
+      ];
+      return (
+        <div style={{ height: '200px' }}>
+          <SelectInput
+            id="customPlaceholder"
+            label="Flavor"
+            helpText="Choose your favorite flavor"
+            onChange={event => setValue(event.target.value)}
+            options={options}
+            value={value}
+            placeholder="Custom placeholder..."
+          />
+        </div>
+      );
+    }}
+  </Story>
+</Canvas>
+
 ## Placeholder
 
 Use the `placeholder` prop to add a custom placeholder.

--- a/src/components/SelectInput/SelectInput.tsx
+++ b/src/components/SelectInput/SelectInput.tsx
@@ -59,6 +59,10 @@ interface SelectInputProps {
    */
   error?: ReactNode;
   /**
+   * Additional clarifying text to help describe the input
+   */
+  helpText?: ReactNode;
+  /**
    * Visually hide the label.
    */
   hideLabel?: boolean;
@@ -105,6 +109,7 @@ const SelectInput: FC<SelectInputProps> = ({
   autoFocus = false,
   className = '',
   error = false,
+  helpText,
   hideLabel = false,
   isClearable = false,
   isDisabled = false,
@@ -144,6 +149,7 @@ const SelectInput: FC<SelectInputProps> = ({
     isFieldRequired: isRequired,
     inputId: id,
     hasError: !!error,
+    helpText,
     className: styles['select-input-label'],
     isDisabled,
   };

--- a/src/components/TextInput/TextInput.stories.mdx
+++ b/src/components/TextInput/TextInput.stories.mdx
@@ -55,6 +55,27 @@ Use the `isRequired` prop to mark the input as required.
   </Story>
 </Canvas>
 
+## With Help Text
+
+Use the `helpText` prop to add clarifying text beneath the input label.
+
+<Canvas>
+  <Story name="Help Text">
+    {() => {
+      const [value, setValue] = useState('');
+      return (
+        <TextInput
+          id="helpText"
+          value={value}
+          label="Mobile Phone"
+          helpText="We willl use this phone number to contact you via text"
+          onChange={event => setValue(event.target.value)}
+        />
+      );
+    }}
+  </Story>
+</Canvas>
+
 ## Placeholder
 
 Use the `placeholder` prop to add a custom placeholder.

--- a/src/components/TextInput/TextInput.tsx
+++ b/src/components/TextInput/TextInput.tsx
@@ -59,6 +59,10 @@ interface TextInputProps {
    */
   hideLabel?: boolean;
   /**
+   * Additional clarifying text to help describe the input
+   */
+  helpText?: ReactNode;
+  /**
    * Pass a value to apply a mask to the input value.
    * Can be one of the existing present strings, or a custom object with options.
    * For options object formats See https://github.com/nosir/cleave.js.
@@ -115,6 +119,7 @@ const TextInput: FC<TextInputProps> = ({
   autoFocus = false,
   className = undefined,
   error = false,
+  helpText,
   hideLabel = false,
   inputMask = undefined,
   isDisabled = false,
@@ -193,6 +198,7 @@ const TextInput: FC<TextInputProps> = ({
     isFieldRequired: isRequired,
     inputId: id,
     hasError: !!error,
+    helpText,
     className: styles['text-input-label'],
     isDisabled,
   };

--- a/src/components/TextareaInput/TextareaInput.stories.mdx
+++ b/src/components/TextareaInput/TextareaInput.stories.mdx
@@ -56,6 +56,27 @@ Use the `isRequired` prop to mark the input as required.
   </Story>
 </Canvas>
 
+## Help Text
+
+Use the `helpText` prop to add clarifying text beneath the input label.
+
+<Canvas>
+  <Story name="Help Text">
+    {() => {
+      const [value, setValue] = useState('');
+      return (
+        <TextareaInput
+          id="helpText"
+          value={value}
+          label="Design Notes"
+          helpText="Add any design requirements or aesthetic choices that the solar system designer should know"
+          onChange={event => setValue(event.target.value)}
+        />
+      );
+    }}
+  </Story>
+</Canvas>
+
 ## Resize
 
 The `resize` prop accepts `horizontal`, `vertical`, `both` or `none` to control the users ability to resize the input.

--- a/src/components/TextareaInput/TextareaInput.tsx
+++ b/src/components/TextareaInput/TextareaInput.tsx
@@ -43,6 +43,10 @@ interface TextareaInputProps {
    */
   error?: ReactNode;
   /**
+   * Additional clarifying text to help describe the input
+   */
+  helpText?: ReactNode;
+  /**
    * Visually hide the label.
    */
   hideLabel?: boolean;
@@ -94,6 +98,7 @@ const TextareaInput: FC<TextareaInputProps> = ({
   autoFocus = false,
   className = undefined,
   error = false,
+  helpText,
   hideLabel = false,
   isDisabled = false,
   isRequired = false,
@@ -134,6 +139,7 @@ const TextareaInput: FC<TextareaInputProps> = ({
     isFieldRequired: isRequired,
     inputId: id,
     hasError: !!error,
+    helpText,
     className: styles['textarea-input-label'],
     isDisabled,
   };

--- a/src/styles/variables/forms.scss
+++ b/src/styles/variables/forms.scss
@@ -2,6 +2,7 @@
   /* ----GLOBALS---- */
 
   --form-control-label-margin: var(--size-spacing-xs);
+  --form-control-help-margin: var(--size-spacing-2xs);
   --form-control-line-height: normal;
 
   /* --SIZES-- */


### PR DESCRIPTION
Allows user to set helpful text that gets placed below the form's label.

TextInput
<img width="446" alt="Screen Shot 2020-10-12 at 10 58 50 AM" src="https://user-images.githubusercontent.com/1447339/95776924-17d04280-0c7a-11eb-8726-d6ef012ff67d.png">

SelectInput
<img width="333" alt="Screen Shot 2020-10-12 at 10 58 43 AM" src="https://user-images.githubusercontent.com/1447339/95776929-1868d900-0c7a-11eb-90f6-f64f9ec683b3.png">

CheckboxInput
<img width="567" alt="Screen Shot 2020-10-12 at 10 58 21 AM" src="https://user-images.githubusercontent.com/1447339/95776930-19016f80-0c7a-11eb-9a78-c14c409cfd64.png">

TextareaInput
<img width="688" alt="Screen Shot 2020-10-12 at 10 58 58 AM" src="https://user-images.githubusercontent.com/1447339/95776922-1737ac00-0c7a-11eb-83ab-c72aed5e381c.png">
