### PR TITLE
removing pr jobs on pushes

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -7,8 +7,6 @@ name: Pull Request
 on:
   pull_request:
     types: [opened, synchronize, reopened]
-  push:
-    branches: [develop, main]
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -25,6 +25,21 @@ jobs:
         run: yarn
       - name: type check
         run: yarn type-check
+  build:
+    name: tbuild
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/cache@v1
+        with:
+          path: ~/.cache/yarn
+          key: ${{ runner.os }}-yarn-${{ hashFiles(format('{0}{1}', github.workspace, '/yarn.lock')) }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+      - name: install dependencies
+        run: yarn
+      - name: build
+        run: yarn build
   lint-js:
     name: lint js
     runs-on: ubuntu-latest


### PR DESCRIPTION
This removes the PR jobs from being run after merging to master. Also adds build job to run on PRs so that we are sure the build is running before firing a release.