### PR TITLE
docs: add introduction, get started, and contributing pages to storybook

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -18,4 +18,15 @@ export const parameters = {
     options: {},
     manual: false,
   },
+  options: {
+    storySort: {
+      order: [
+        'About',
+        ['Introduction', 'Get Started', 'Contributing'],
+        'Components',
+        'Patterns',
+        'Design Tokens',
+      ],
+    },
+  },
 };

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ look of all components across applications.
 
 ```jsx
 import React from 'react';
+import ReactDOM from 'react-dom';
 import { Button } from '@palmetto/palmetto-components';
 
 function App() {

--- a/README.md
+++ b/README.md
@@ -40,7 +40,6 @@ look of all components.
 
 ```jsx
 import React from 'react';
-import ReactDOM from 'react-dom';
 import { Button } from '@palmetto/palmetto-components';
 
 function App() {

--- a/README.md
+++ b/README.md
@@ -25,15 +25,16 @@
 
 ### 2. Import Global CSS
 
-```
+```jsx
 @import '@palmetto/palmetto-components/dist/css/utilities.css';
 @import '@palmetto/palmetto-components/dist/css/variables.css';
 ```
 
-Not required but we also recommend importing our global reset in order to properly maintain the
-look of all components.
-```
-@import '@palmetto/palmetto-components/dist/css/reset.scss'
+We recommend importing our global reset in order to maintain a consistent
+look of all components across applications.
+
+```jsx
+@import '@palmetto/palmetto-components/dist/css/reset.css'
 ```
 
 ### 3. Usage

--- a/src/docs/Contributing.stories.mdx
+++ b/src/docs/Contributing.stories.mdx
@@ -1,0 +1,7 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+
+<Meta title="About/Contributing" />
+
+# Contributing
+
+Check out our robust contribution guide on github: [Palmetto Components Contribution Guide](https://github.com/palmetto/palmetto-components/blob/main/docs/CONTRIBUTING.md)

--- a/src/docs/GetStarted.stories.mdx
+++ b/src/docs/GetStarted.stories.mdx
@@ -1,0 +1,40 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+
+<Meta title="About/Get Started" />
+
+# Get Started
+
+### 1. Install
+
+`yarn add @palmetto/palmetto-components`
+
+or
+
+`npm add @palmetto/palmetto-components`
+
+### 2. Import Global CSS
+
+```
+@import '@palmetto/palmetto-components/dist/css/utilities.css';
+@import '@palmetto/palmetto-components/dist/css/variables.css';
+```
+
+Not required but we also recommend importing our global reset in order to properly maintain the
+look of all components.
+
+```
+@import '@palmetto/palmetto-components/dist/css/reset.scss'
+```
+
+### 3. Usage
+
+```jsx
+import React from 'react';
+import { Button } from '@palmetto/palmetto-components';
+
+function App() {
+  return <Button>Hello World</Button>;
+}
+
+ReactDOM.render(<App />, document.querySelector('#app'));
+```

--- a/src/docs/GetStarted.stories.mdx
+++ b/src/docs/GetStarted.stories.mdx
@@ -30,6 +30,7 @@ look of all components across applications.
 
 ```jsx
 import React from 'react';
+import ReactDOM from 'react-dom';
 import { Button } from '@palmetto/palmetto-components';
 
 function App() {

--- a/src/docs/GetStarted.stories.mdx
+++ b/src/docs/GetStarted.stories.mdx
@@ -10,20 +10,20 @@ import { Meta } from '@storybook/addon-docs/blocks';
 
 or
 
-`npm add @palmetto/palmetto-components`
+`npm install @palmetto/palmetto-components`
 
 ### 2. Import Global CSS
 
-```
+```jsx
 @import '@palmetto/palmetto-components/dist/css/utilities.css';
 @import '@palmetto/palmetto-components/dist/css/variables.css';
 ```
 
-Not required but we also recommend importing our global reset in order to properly maintain the
-look of all components.
+We recommend importing our global reset in order to maintain a consistent
+look of all components across applications.
 
-```
-@import '@palmetto/palmetto-components/dist/css/reset.scss'
+```jsx
+@import '@palmetto/palmetto-components/dist/css/reset.css'
 ```
 
 ### 3. Usage

--- a/src/docs/Intro.stories.mdx
+++ b/src/docs/Intro.stories.mdx
@@ -4,7 +4,7 @@ import { Meta } from '@storybook/addon-docs/blocks';
 
 # Palmetto Design System
 
-Welcome to the Palmetto Design System, whose purpose is to help us deliver high quality Palmetto branded experiences, faster and better. It consists of the following following:
+Welcome to the Palmetto Design System, whose purpose is to help us deliver high quality Palmetto branded applications, faster and better. It consists of the following following:
 
 - [Palmetto Components](https://github.com/palmetto/palmetto-components) - on open source, react-based, component library for Palmetto applications and websites.
 - [Palmetto Design Tokens](https://github.com/palmetto/palmetto-design-tokens) - A central location to store shared attributes of the Palmetto Design System. These include things like color, fonts, spacing, and more.

--- a/src/docs/Intro.stories.mdx
+++ b/src/docs/Intro.stories.mdx
@@ -4,13 +4,13 @@ import { Meta } from '@storybook/addon-docs/blocks';
 
 # Palmetto Design System
 
-Welcome to the Palmetto Design System, whose purpose is to help us deliver high quality Palmetto branded applications, faster and better. It consists of the following following:
+Welcome to the Palmetto Design System, whose purpose is to help us deliver high quality Palmetto branded applications, faster and better. It consists of the following:
 
-- [Palmetto Components](https://github.com/palmetto/palmetto-components) - on open source, react-based, component library for Palmetto applications and websites.
+- [Palmetto Components](https://github.com/palmetto/palmetto-components) - an open source, react-based, component library for Palmetto applications and websites.
 - [Palmetto Design Tokens](https://github.com/palmetto/palmetto-design-tokens) - A central location to store shared attributes of the Palmetto Design System. These include things like color, fonts, spacing, and more.
 - Brand Assets: _coming soon_
 - Voice and Tone: _coming soon_
 
-If you have any questions or concerns, please feel to reach out to the UX Team on Slack (#ux). One of our missions is build tools to make your job easier and more succesful, so please don't hesitate to reach out.
+If you have any questions or concerns, please feel free to reach out to the UX Team on Slack (#ux). One of our missions is build tools to make your job easier and you more successful, so please don't hesitate to reach out.
 
 The Palmetto UX Team

--- a/src/docs/Intro.stories.mdx
+++ b/src/docs/Intro.stories.mdx
@@ -1,0 +1,16 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+
+<Meta title="About/Introduction" />
+
+# Palmetto Design System
+
+Welcome to the Palmetto Design System, whose purpose is to help us deliver high quality Palmetto branded experiences, faster and better. It consists of the following following:
+
+- [Palmetto Components](https://github.com/palmetto/palmetto-components) - on open source, react-based, component library for Palmetto applications and websites.
+- [Palmetto Design Tokens](https://github.com/palmetto/palmetto-design-tokens) - A central location to store shared attributes of the Palmetto Design System. These include things like color, fonts, spacing, and more.
+- Brand Assets: _coming soon_
+- Voice and Tone: _coming soon_
+
+If you have any questions or concerns, please feel to reach out to the UX Team on Slack (#ux). One of our missions is build tools to make your job easier and more succesful, so please don't hesitate to reach out.
+
+The Palmetto UX Team


### PR DESCRIPTION
- Adds some basic pages for 
  - Introduction
  - Get Started
  - Contributing
- Sets the order of the items in the storybook left nav

<img width="1083" alt="Screen Shot 2020-10-26 at 3 05 03 PM" src="https://user-images.githubusercontent.com/1447339/97233714-a4abed80-179c-11eb-8d32-295cc795dc55.png">

