### PR TITLE
fix(Box): prevent flex direction classes from being added twice

### DIFF
--- a/src/components/Box/Box.tsx
+++ b/src/components/Box/Box.tsx
@@ -224,7 +224,6 @@ const Box: FC<BoxProps> = ({
     generateResponsiveClasses('font-size', fontSize),
     generateResponsiveClasses('overflow', overflow),
     generateResponsiveClasses('border-radius', radius),
-    generateResponsiveClasses('flex-direction', direction),
     generateResponsiveClasses('flex', flex),
     generateResponsiveClasses('background-color', background),
     cssShorthandToClasses('border-width', borderWidth),


### PR DESCRIPTION
We are accidentally calling `generateResponsiveClasses('flex-direction', direction),` which adds the `flex-direction-column` or `flex-direction-row` class twice to the element. This removes 1 of the calls so only 1 class name is added.

<img width="975" alt="Screen Shot 2020-10-26 at 6 31 28 PM" src="https://user-images.githubusercontent.com/1447339/97246012-8dc7c400-17b9-11eb-8fc2-c7fd6ac1f7cc.png">
