### PR TITLE
fix: if a user specifies '0' as a spacing value, return the corresponding css className

### DIFF
--- a/src/lib/cssShorthandToClasses.test.ts
+++ b/src/lib/cssShorthandToClasses.test.ts
@@ -22,7 +22,7 @@ describe('cssShorthandToClasses', () => {
     test('returns expected css object if vertical and horizontal are set to 0', () => {
       const spacingClasses = cssShorthandToClasses('p', '0 0');
 
-      expect(spacingClasses).toEqual([]);
+      expect(spacingClasses).toEqual(['p-v-0', 'p-h-0']);
     });
   });
 
@@ -36,7 +36,11 @@ describe('cssShorthandToClasses', () => {
     test('returns expected css object if top, horizontal and bottom spacing values are set to 0', () => {
       const spacingClasses = cssShorthandToClasses('p', '0 0 0');
 
-      expect(spacingClasses).toEqual([]);
+      expect(spacingClasses).toEqual([
+        'p-top-0',
+        'p-h-0',
+        'p-bottom-0',
+      ]);
     });
   });
 
@@ -50,7 +54,12 @@ describe('cssShorthandToClasses', () => {
     test('returns expected css object if top, right, bottom, left spacing values are set to 0', () => {
       const spacingClasses = cssShorthandToClasses('p', '0 0 0 0');
 
-      expect(spacingClasses).toEqual([]);
+      expect(spacingClasses).toEqual([
+        'p-top-0',
+        'p-right-0',
+        'p-bottom-0',
+        'p-left-0',
+      ]);
     });
   });
 
@@ -65,6 +74,17 @@ describe('cssShorthandToClasses', () => {
         'p-right-md-tablet',
         'p-bottom-lg-tablet',
         'p-left-xl-tablet',
+      ]);
+    });
+
+    test('returns expected css object if an object is passed with spacing 0 for particular breakpoints', () => {
+      const spacingClasses = cssShorthandToClasses('p', { base: '3xl 0', desktop: '0 3xl' });
+
+      expect(spacingClasses).toEqual([
+        'p-v-3xl',
+        'p-h-0',
+        'p-v-0-desktop',
+        'p-h-3xl-desktop',
       ]);
     });
   });

--- a/src/lib/cssShorthandToClasses.ts
+++ b/src/lib/cssShorthandToClasses.ts
@@ -33,10 +33,7 @@ function generateBaseClasses(
     const sides = value.split(' ');
 
     sides.forEach((v, index) => {
-      // Exception for border width since we want to default borders to zero.
-      if (v !== '0' || attribute === 'border-width') {
-        classes.push(`${attribute}-${shorthand[sides.length][index]}-${v}`);
-      }
+      classes.push(`${attribute}-${shorthand[sides.length][index]}-${v}`);
     });
   } else {
     classes.push(`${attribute}-${value}`);


### PR DESCRIPTION
We have utility classes that set margin and padding values to 0, but we don't use them currently because the `cssShorthandToClasses` function only returns classnames if a value is not equal to zero or a border width. 

This prevents us from setting a spacing value to 0 at different breakpoints (see linked issue)

This change always returns a css classname if the spacing value is valid.