### PR TITLE
fix(Modal): increase width to 70% of viewport on tablets

### DIFF
--- a/src/components/Modal/Modal.module.scss
+++ b/src/components/Modal/Modal.module.scss
@@ -76,7 +76,7 @@
     outline: none;
     border-radius: var(--modal-border-radius);
     box-shadow: var(--size-box-shadow-sm);
-    width: 60vw;
+    width: 70vw;
     min-height: unset;
     max-height: calc(100vh - 80px);
     animation: zoomIn 0.2s ease-out;

--- a/src/components/Modal/Modal.module.scss
+++ b/src/components/Modal/Modal.module.scss
@@ -76,10 +76,14 @@
     outline: none;
     border-radius: var(--modal-border-radius);
     box-shadow: var(--size-box-shadow-sm);
-    width: 50vw;
+    width: 60vw;
     min-height: unset;
     max-height: calc(100vh - 80px);
     animation: zoomIn 0.2s ease-out;
+  }
+
+  @media(min-width: $size-breakpoint-desktop) {
+    width: 50vw;
   }
 }
 


### PR DESCRIPTION
before on tablet, the modal looks too narrow and unbalanced:
<img width="787" alt="Screen Shot 2020-11-04 at 4 06 21 PM" src="https://user-images.githubusercontent.com/1447339/98181272-b20d5a00-1eb7-11eb-823a-be1532dd8cec.png">

this pr increases the width on tablets so that content appears more balanced:
<img width="787" alt="Screen Shot 2020-11-04 at 4 06 12 PM" src="https://user-images.githubusercontent.com/1447339/98181295-bb96c200-1eb7-11eb-89ea-3037b80baee4.png">
