### PR TITLE
fix: dont reset ol, ul list types because browser default is ok

### DIFF
--- a/src/styles/reset.scss
+++ b/src/styles/reset.scss
@@ -19,15 +19,16 @@ body {
   /* Core body defaults */
   text-rendering: optimizeSpeed;
   /* Setting font family and default px value (to be used by our rem units downstream) */
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell,
+    'Open Sans', 'Helvetica Neue', sans-serif;
   font-size: 16px;
   scroll-behavior: smooth;
 }
 
 /* Standardize list styles on ul, ol elements */
-ul, ol { /* stylelint-disable-line */
+ul,
+ol {
   display: block;
-  list-style-type: disc;
   margin-block-start: 1em;
   margin-block-end: 1em;
   margin-inline-start: 0;
@@ -68,7 +69,8 @@ figure,
 figcaption,
 blockquote,
 dl,
-dd { /* stylelint-enable */
+dd {
+  /* stylelint-enable */
   margin: 0;
 }
 


### PR DESCRIPTION
Because of our reset.scss, using an order list `ol` element renders a bullet list instead of numbered list. 

This change fixes that by removing the `list-style-type` property, and relying on the browser default to set the list type.