### PR TITLE
feat(types): export all prop interfaces

### DIFF
--- a/src/components/Alert/Alert.tsx
+++ b/src/components/Alert/Alert.tsx
@@ -10,7 +10,7 @@ import { BrandColor, FontColor, IconName } from '../../types';
 
 export type AlertVariant = 'default' | 'info' | 'success' | 'warning' | 'danger';
 export type AlertAttributes = { icon: IconName; color: FontColor; background: BrandColor; };
-interface AlertProps {
+export interface AlertProps {
   /**
    * Custom class to apply to the alert.
    */

--- a/src/components/Badge/Badge.tsx
+++ b/src/components/Badge/Badge.tsx
@@ -16,7 +16,7 @@ export type BadgeVariant = 'info' | 'primary' | 'success' | 'secondary' | 'terti
 export type BadgeColorAttributes = { font: FontColor; background: BrandColor; };
 export type BadgeSizeAttributes = { fontSize: FontSize; padding: BaseSpacing; };
 
-interface BadgeProps {
+export interface BadgeProps {
   /**
    * Custom class to apply to the badge container div.
    */

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -14,7 +14,7 @@ import styles from './Button.module.scss';
 export type ButtonVariant = 'primary' | 'success' | 'danger' | 'light' | 'dark';
 export type ButtonSize = 'xs' | 'sm' | 'md' | 'lg';
 
-interface ButtonProps {
+export interface ButtonProps {
   /**
    * Contents of the button.
    */

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -21,7 +21,7 @@ type BoxPropsShallow = Omit<BoxProps,
   'display'
 >;
 
-interface CardProps extends BoxPropsShallow {
+export interface CardProps extends BoxPropsShallow {
   /**
    * visually subdued the appearance of the entire card
    */

--- a/src/components/CheckboxInput/CheckboxInput.tsx
+++ b/src/components/CheckboxInput/CheckboxInput.tsx
@@ -10,7 +10,7 @@ import FormLabel from '../FormLabel/FormLabel';
 import Box from '../Box/Box';
 import styles from './CheckboxInput.module.scss';
 
-interface CheckboxInputProps {
+export interface CheckboxInputProps {
   /**
    * The id attribute of the input.
    */

--- a/src/components/DateInput/DateInput.tsx
+++ b/src/components/DateInput/DateInput.tsx
@@ -4,7 +4,7 @@ import DatePicker, { DatePickerProps } from '../DatePicker/DatePicker';
 import TextInput, { TextInputBaseProps } from '../TextInput/TextInput';
 import Popover, { PopoverProps } from '../Popover/Popover';
 
-interface DateInputProps {
+export interface DateInputProps {
   datePickerProps: DatePickerProps;
   textInputProps: TextInputBaseProps;
   dateFormat?: string;

--- a/src/components/FileUpload/FileUpload.tsx
+++ b/src/components/FileUpload/FileUpload.tsx
@@ -7,7 +7,7 @@ import FormLabel from '../FormLabel/FormLabel';
 import InputValidationMessage from '../InputValidationMessage/InputValidationMessage';
 import Button, { ButtonSize } from '../Button/Button';
 
-interface FileUploadProps {
+export interface FileUploadProps {
   /**
    * Id for the file input element.
    */

--- a/src/components/FormLabel/FormLabel.tsx
+++ b/src/components/FormLabel/FormLabel.tsx
@@ -3,7 +3,7 @@ import classNames from 'classnames';
 import Box from '../Box/Box';
 import styles from './FormLabel.module.scss';
 
-interface FormLabelProps {
+export interface FormLabelProps {
   /**
    * Content to be rendered inside the label.
    */

--- a/src/components/Heading/Heading.tsx
+++ b/src/components/Heading/Heading.tsx
@@ -9,7 +9,7 @@ import {
 import { HEADING_LEVELS_TYPE, HEADING_DEFAULT_SIZE_MAP } from './Heading.constants';
 import styles from './Heading.module.scss';
 
-interface HeadingProps {
+export interface HeadingProps {
   /**
    * The DOM tag or react component to use for the element.
    * Select the appropriate semantic element (h1-h6).

--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -3,7 +3,7 @@ import icons from '@palmetto/palmetto-design-tokens/build/icons/react';
 import { IconName } from '../../types';
 import Box from '../Box/Box';
 
-interface IconProps {
+export interface IconProps {
   className?: string;
   name: IconName;
   /**

--- a/src/components/InputValidationMessage/InputValidationMessage.tsx
+++ b/src/components/InputValidationMessage/InputValidationMessage.tsx
@@ -5,7 +5,7 @@ import classNames from 'classnames';
  * Used by form inputs such as TextInput, to display a validation message for an invalid input.
  */
 
-interface InputValidationMessageProps {
+export interface InputValidationMessageProps {
   children: ReactNode;
   size?: 'xs' | 'sm' | 'md';
 }

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -5,7 +5,7 @@ import { ModalFooter, ModalHeader, ModalBody } from './components';
 import { CssOverflowValue } from '../../types';
 import styles from './Modal.module.scss';
 
-interface ModalProps {
+export interface ModalProps {
   /**
    * Handle zoom/pinch gestures on iOS devices when scroll locking is enabled.
    */

--- a/src/components/Modal/components/ModalBody/ModalBody.tsx
+++ b/src/components/Modal/components/ModalBody/ModalBody.tsx
@@ -1,7 +1,7 @@
 import React, { FC } from 'react';
 import Box, { BoxProps } from '../../../Box/Box';
 
-type ModalBodyProps = Omit<BoxProps, 'as' | 'radius'>;
+export type ModalBodyProps = Omit<BoxProps, 'as' | 'radius'>;
 
 const ModalBody: FC<ModalBodyProps> = ({
   children,

--- a/src/components/Modal/components/ModalFooter/ModalFooter.tsx
+++ b/src/components/Modal/components/ModalFooter/ModalFooter.tsx
@@ -1,7 +1,7 @@
 import React, { FC } from 'react';
 import Box, { BoxProps } from '../../../Box/Box';
 
-type ModalFooterProps = Omit<
+export type ModalFooterProps = Omit<
   BoxProps,
   'as' | 'background' | 'borderColor' | 'borderWidth' | 'radius'
 >;

--- a/src/components/Modal/components/ModalHeader/ModalHeader.tsx
+++ b/src/components/Modal/components/ModalHeader/ModalHeader.tsx
@@ -3,7 +3,7 @@ import Box from '../../../Box/Box';
 import Icon from '../../../Icon/Icon';
 import styles from '../../Modal.module.scss';
 
-type ModalHeaderProps = {
+export type ModalHeaderProps = {
   /**
    * id of the element containing the title, used by the Modal `aria-labelledby` prop
    */

--- a/src/components/Pagination/Pagination.tsx
+++ b/src/components/Pagination/Pagination.tsx
@@ -3,7 +3,7 @@ import classNames from 'classnames';
 import Box from '../Box/Box';
 import Button from '../Button/Button';
 
-interface PaginationProps {
+export interface PaginationProps {
   /**
    * The current page number being displayed.
    */

--- a/src/components/RadioGroup/RadioGroup.tsx
+++ b/src/components/RadioGroup/RadioGroup.tsx
@@ -7,7 +7,7 @@ import InputValidationMessage from '../InputValidationMessage/InputValidationMes
 import RadioInput from './RadioInput/RadioInput';
 import styles from './RadioGroup.module.scss';
 
-interface RadioGroupProps {
+export interface RadioGroupProps {
   /**
    * Radio group name.
    */

--- a/src/components/SelectInput/SelectInput.tsx
+++ b/src/components/SelectInput/SelectInput.tsx
@@ -103,7 +103,7 @@ export interface BaseSelectInputProps {
    */
   [x: string]: any; // eslint-disable-line
 }
-interface SelectInputProps extends BaseSelectInputProps {
+export interface SelectInputProps extends BaseSelectInputProps {
   /**
    * Options for dropdown list.
    */

--- a/src/components/Spinner/Spinner.tsx
+++ b/src/components/Spinner/Spinner.tsx
@@ -4,7 +4,7 @@ import { BRAND_COLORS } from '../../lib/tokens';
 import { ColorName } from '../../types';
 import styles from './Spinner.module.scss';
 
-interface SpinnerProps {
+export interface SpinnerProps {
   /**
    * Custom className to be applied to spinner container div element.
    */

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -6,7 +6,7 @@ import styles from './Table.module.scss';
 import TableBody from './TableBody/TableBody';
 import TableHead from './TableHead/TableHead';
 
-interface TableProps {
+export interface TableProps {
   /**
    * Columns for the table. See Column definition below for details.
    */

--- a/src/components/Table/TableBody/TableBody.tsx
+++ b/src/components/Table/TableBody/TableBody.tsx
@@ -4,7 +4,7 @@ import styles from './TableBody.module.scss';
 import { Column, Row } from '../../../types';
 import TableRow from '../common/TableRow/TableRow';
 
-interface TableBodyProps {
+export interface TableBodyProps {
   /**
    * The table columns to be rendered
    */

--- a/src/components/Table/TableBody/TableBodyCell/TableBodyCell.tsx
+++ b/src/components/Table/TableBody/TableBodyCell/TableBodyCell.tsx
@@ -2,7 +2,7 @@ import React, { FC, ReactNode } from 'react';
 import classNames from 'classnames';
 import styles from './TableBodyCell.module.scss';
 
-interface TableBodyCellProps {
+export interface TableBodyCellProps {
   /**
    * Text alignment for all table cells. Can be superseded by passing the same prop into the `Column` object
    * for a specific column.

--- a/src/components/Table/TableHead/TableHead.tsx
+++ b/src/components/Table/TableHead/TableHead.tsx
@@ -3,7 +3,7 @@ import classNames from 'classnames';
 import { Column, EventWithColumnKey } from '../../../types';
 import TableRow from '../common/TableRow/TableRow';
 
-interface TableHeadProps {
+export interface TableHeadProps {
   /**
    * The table columns to be rendered
    */

--- a/src/components/Table/common/TableRow/TableRow.tsx
+++ b/src/components/Table/common/TableRow/TableRow.tsx
@@ -6,7 +6,7 @@ import getColumnKeys from '../../../../lib/getColumnKeys';
 import TableBodyCell from '../../TableBody/TableBodyCell/TableBodyCell';
 import TableHeaderCell from '../../TableHead/TableHeaderCell/TableHeaderCell';
 
-interface TableRowProps {
+export interface TableRowProps {
   /**
    * The table columns to be rendered
    */

--- a/src/components/TextInput/TextInput.tsx
+++ b/src/components/TextInput/TextInput.tsx
@@ -10,6 +10,7 @@ import React, {
 } from 'react';
 import classNames from 'classnames';
 import Cleave from 'cleave.js/react';
+import { ChangeEvent as CleaveChangeEvent } from 'cleave.js/react/props';
 import { UnknownPropertiesObjType } from '../../types';
 import * as InputMasks from './TextInputMasks';
 import Box from '../Box/Box';
@@ -108,7 +109,7 @@ export interface TextInputProps extends TextInputBaseProps {
   /**
    * Callback function to call on change event.
    */
-  onChange: (event: ChangeEvent<HTMLInputElement>) => void;
+  onChange: (event: ChangeEvent<HTMLInputElement> | CleaveChangeEvent<HTMLInputElement>) => void;
   /**
    * The text value of the input. Required since our Input is a controlled component.
    */

--- a/src/components/TextLink/TextLink.tsx
+++ b/src/components/TextLink/TextLink.tsx
@@ -3,7 +3,7 @@ import { LinkProps } from 'react-router-dom';
 import classNames from 'classnames';
 import styles from './TextLink.module.scss';
 
-interface TextLinkBaseProps {
+export interface TextLinkBaseProps {
   /**
    * Custom class to be passed to the link.
    */

--- a/src/components/TextareaInput/TextareaInput.tsx
+++ b/src/components/TextareaInput/TextareaInput.tsx
@@ -8,7 +8,7 @@ import InputValidationMessage from '../InputValidationMessage/InputValidationMes
 import getAutoCompleteValue from '../../lib/getAutoCompleteValue';
 import styles from './TextareaInput.module.scss';
 
-interface TextareaInputProps {
+export interface TextareaInputProps {
   /**
    * The input's id attribute. Used to programmatically tie the input with its label.
    */

--- a/src/components/TimePicker/TimePicker.tsx
+++ b/src/components/TimePicker/TimePicker.tsx
@@ -1,7 +1,7 @@
 import React, { FC } from 'react';
 import SelectInput, { BaseSelectInputProps } from '../SelectInput/SelectInput';
 
-interface TimePickerProps extends BaseSelectInputProps {
+export interface TimePickerProps extends BaseSelectInputProps {
   /**
    * Options to govern the display of the option labels in the select.
    * This is a direct passthrough to the second argument of JS `toLocaleTimeString`.

--- a/src/components/Toggle/Toggle.tsx
+++ b/src/components/Toggle/Toggle.tsx
@@ -7,7 +7,7 @@ import FormLabel from '../FormLabel/FormLabel';
 import Box from '../Box/Box';
 import styles from './Toggle.module.scss';
 
-interface ToggleProps {
+export interface ToggleProps {
   /**
    * The id attribute of the input.
    */


### PR DESCRIPTION
We might want to explore some better ways to make these interfaces available but for the time being this works and is helpful for library consumers extending our components since they can then extend the base props without having to re-write them.