### PR TITLE
feat(TextInput): prefix and suffix option

### DIFF
--- a/src/components/DatePicker/DatePicker.stories.mdx
+++ b/src/components/DatePicker/DatePicker.stories.mdx
@@ -19,7 +19,7 @@ Use a DatePicker when a user needs to select a date and time.
 <Canvas>
   <Story name="Basic Example">
     {() => {
-      const [selectedDate, setSelectedDate] = useState(new Date(2020, 11, 3));
+      const [selectedDate, setSelectedDate] = useState(new Date(2019, 11, 3));
       return (
         <Box childGap="md">
           <DatePicker onChange={setSelectedDate} selected={selectedDate} />
@@ -35,8 +35,8 @@ Use a DatePicker when a user needs to select a date and time.
 <Canvas>
   <Story name="date range">
     {() => {
-      const [startDate, setStartDate] = useState(new Date(2020, 11, 3));
-      const [endDate, setEndDate] = useState(new Date(2020, 11, 28));
+      const [startDate, setStartDate] = useState(new Date(2019, 11, 3));
+      const [endDate, setEndDate] = useState(new Date(2019, 11, 28));
       const setDate = ([startDate, endDate]) => {
         setStartDate(startDate);
         setEndDate(endDate);
@@ -66,10 +66,10 @@ Use a DatePicker when a user needs to select a date and time.
 <Canvas>
   <Story name="Min/max dates">
     {() => {
-      const [startDate, setStartDate] = useState(new Date(2020, 11, 18));
-      const min = new Date(2020, 11, 18);
+      const [startDate, setStartDate] = useState(new Date(2019, 11, 18));
+      const min = new Date(2019, 11, 18);
       min.setDate(min.getDate() - 5);
-      const max = new Date(2020, 11, 18);
+      const max = new Date(2019, 11, 18);
       max.setDate(max.getDate() + 5);
       return (
         <Box childGap="md">
@@ -86,9 +86,9 @@ Use a DatePicker when a user needs to select a date and time.
 <Canvas>
   <Story name="month picker">
     {() => {
-      const [startDateOne, setStartDateOne] = useState(new Date(2020, 10));
-      const [startDateTwo, setStartDateTwo] = useState(new Date(2020, 10));
-      const [startDateThree, setStartDateThree] = useState(new Date(2020, 10));
+      const [startDateOne, setStartDateOne] = useState(new Date(2019, 10));
+      const [startDateTwo, setStartDateTwo] = useState(new Date(2019, 10));
+      const [startDateThree, setStartDateThree] = useState(new Date(2019, 10));
       return (
         <Box display="flex" direction="row" childGap="md">
           <Box childGap="md" display="flex" direction="column" alignItems="center" width="33">
@@ -131,8 +131,8 @@ Use a DatePicker when a user needs to select a date and time.
 <Canvas>
   <Story name="Multiple Months">
     {() => {
-      const [startDate, setStartDate] = useState(new Date(2020, 11, 3));
-      const [endDate, setEndDate] = useState(new Date(2020, 12, 20));
+      const [startDate, setStartDate] = useState(new Date(2019, 11, 3));
+      const [endDate, setEndDate] = useState(new Date(2019, 12, 20));
       const setDate = ([startDate, endDate]) => {
         console.log(startDate, endDate);
         setStartDate(startDate);
@@ -203,7 +203,7 @@ Use a DatePicker when a user needs to select a date and time.
 <Canvas>
   <Story name="with children">
     {() => {
-      const [selectedDate, setSelectedDate] = useState(new Date(2020, 11, 3));
+      const [selectedDate, setSelectedDate] = useState(new Date(2019, 11, 3));
       return (
         <Box childGap="md">
           <DatePicker onChange={setSelectedDate} selected={selectedDate}>
@@ -223,7 +223,7 @@ Use a DatePicker when a user needs to select a date and time.
 <Canvas>
   <Story name="day classname">
     {() => {
-      const [selectedDate, setSelectedDate] = useState(new Date(2020, 11, 3));
+      const [selectedDate, setSelectedDate] = useState(new Date(2019, 11, 3));
       return (
         <Box childGap="md">
           <DatePicker

--- a/src/components/TextInput/TextInput.module.scss
+++ b/src/components/TextInput/TextInput.module.scss
@@ -97,21 +97,15 @@
 
   .clear-button {
     /* Reset default button styles */
+    transition-duration: 0.2s;
+    transition-property: color;
     border: 0;
-    border-radius: none;
+    border-radius: 0;
     background: none;
     cursor: pointer;
     padding-left: 0;
-    color: inherit;
-    font-style: inherit;
-  }
-
-  .clear-icon {
-    display: block;
-    transition-duration: 0.2s;
-    transition-property: color;
-    cursor: pointer;
     color: var(--form-control-icon-color);
+    font-style: inherit;
 
     &:hover {
       color: var(--form-control-icon-hover-color);

--- a/src/components/TextInput/TextInput.module.scss
+++ b/src/components/TextInput/TextInput.module.scss
@@ -56,7 +56,7 @@
     padding: 0 var(--form-control-size-sm-padding);
     font-size: var(--form-control-size-sm-font-size);
 
-    > input {
+    > * {
       padding-top: calc(var(--form-control-size-sm-padding) - 1px);
       padding-bottom: calc(var(--form-control-size-sm-padding) - 1px);
     }
@@ -67,7 +67,7 @@
     padding: 0 var(--form-control-size-md-padding);
     font-size: var(--form-control-size-md-font-size);
 
-    > input {
+    > * {
       padding-top: calc(var(--form-control-size-md-padding) - 1px);
       padding-bottom: calc(var(--form-control-size-md-padding) - 1px);
     }
@@ -78,7 +78,7 @@
     padding: 0 var(--form-control-size-lg-padding);
     font-size: var(--form-control-size-lg-font-size);
 
-    > input {
+    > * {
       padding-top: calc(var(--form-control-size-lg-padding) - 1px);
       padding-bottom: calc(var(--form-control-size-lg-padding) - 1px);
     }
@@ -98,9 +98,10 @@
   .clear-button {
     /* Reset default button styles */
     border: 0;
+    border-radius: none;
     background: none;
     cursor: pointer;
-    padding: 0;
+    padding-left: 0;
     color: inherit;
     font-style: inherit;
   }

--- a/src/components/TextInput/TextInput.module.scss
+++ b/src/components/TextInput/TextInput.module.scss
@@ -57,7 +57,7 @@
     font-size: var(--form-control-size-sm-font-size);
 
     > input {
-      padding: calc(var(--form-control-size-sm-padding) - 1px);
+      padding: calc(var(--form-control-size-sm-padding) - 1px) 0;
     }
   }
 
@@ -77,7 +77,7 @@
     font-size: var(--form-control-size-lg-font-size);
 
     > input {
-      padding: calc(var(--form-control-size-lg-padding) - 1px);
+      padding: calc(var(--form-control-size-lg-padding) - 1px) 0;
     }
   }
 

--- a/src/components/TextInput/TextInput.module.scss
+++ b/src/components/TextInput/TextInput.module.scss
@@ -57,7 +57,8 @@
     font-size: var(--form-control-size-sm-font-size);
 
     > input {
-      padding: calc(var(--form-control-size-sm-padding) - 1px) 0;
+      padding-top: calc(var(--form-control-size-sm-padding) - 1px);
+      padding-bottom: calc(var(--form-control-size-sm-padding) - 1px);
     }
   }
 
@@ -67,7 +68,8 @@
     font-size: var(--form-control-size-md-font-size);
 
     > input {
-      padding: calc(var(--form-control-size-md-padding) - 1px) 0;
+      padding-top: calc(var(--form-control-size-md-padding) - 1px);
+      padding-bottom: calc(var(--form-control-size-md-padding) - 1px);
     }
   }
 
@@ -77,7 +79,8 @@
     font-size: var(--form-control-size-lg-font-size);
 
     > input {
-      padding: calc(var(--form-control-size-lg-padding) - 1px) 0;
+      padding-top: calc(var(--form-control-size-lg-padding) - 1px);
+      padding-bottom: calc(var(--form-control-size-lg-padding) - 1px);
     }
   }
 
@@ -108,7 +111,6 @@
     transition-property: color;
     cursor: pointer;
     color: var(--form-control-icon-color);
-    font-size: var(--form-control-text-clear-icon-font-size);
 
     &:hover {
       color: var(--form-control-icon-hover-color);

--- a/src/components/TextInput/TextInput.module.scss
+++ b/src/components/TextInput/TextInput.module.scss
@@ -53,8 +53,12 @@
 
   &.sm {
     border-radius: var(--form-control-size-sm-border-radius);
-    padding: calc(var(--form-control-size-sm-padding) - 1px) var(--form-control-size-sm-padding);
+    padding: 0 var(--form-control-size-sm-padding);
     font-size: var(--form-control-size-sm-font-size);
+
+    > input {
+      padding: calc(var(--form-control-size-sm-padding) - 1px);
+    }
   }
 
   &.md {
@@ -69,8 +73,12 @@
 
   &.lg {
     border-radius: var(--form-control-size-lg-border-radius);
-    padding: calc(var(--form-control-size-lg-padding) - 1px) var(--form-control-size-lg-padding);
+    padding: 0 var(--form-control-size-lg-padding);
     font-size: var(--form-control-size-lg-font-size);
+
+    > input {
+      padding: calc(var(--form-control-size-lg-padding) - 1px);
+    }
   }
 
   &.error {

--- a/src/components/TextInput/TextInput.module.scss
+++ b/src/components/TextInput/TextInput.module.scss
@@ -9,6 +9,9 @@
 
 .text-input-wrapper {
   position: relative;
+  border: 1px solid var(--form-control-border-color);
+  box-shadow: var(--form-control-size-box-shadow);
+  background-color: var(--form-control-background-color);
 
   &:focus-within {
     outline: none;
@@ -25,9 +28,8 @@
     transition-duration: 300ms;
     transition-property: border, background-color;
     transition-timing-function: cubic-bezier(0.2, 0.8, 0.4, 1);
-    border: 1px solid var(--form-control-border-color);
-    box-shadow: var(--form-control-size-box-shadow);
-    background-color: var(--form-control-background-color);
+    border: none;
+    background: none;
     width: 100%;
     line-height: var(--form-control-text-line-height);
     color: var(--form-control-font-color);
@@ -50,48 +52,40 @@
   }
 
   &.sm {
-    > input {
-      border-radius: var(--form-control-size-sm-border-radius);
-      padding: calc(var(--form-control-size-sm-padding) - 1px) var(--form-control-size-sm-padding);
-      font-size: var(--form-control-size-sm-font-size);
-    }
+    border-radius: var(--form-control-size-sm-border-radius);
+    padding: calc(var(--form-control-size-sm-padding) - 1px) var(--form-control-size-sm-padding);
+    font-size: var(--form-control-size-sm-font-size);
   }
 
   &.md {
+    border-radius: var(--form-control-size-md-border-radius);
+    padding: 0 var(--form-control-size-md-padding);
+    font-size: var(--form-control-size-md-font-size);
+
     > input {
-      border-radius: var(--form-control-size-md-border-radius);
-      padding: calc(var(--form-control-size-md-padding) - 1px) var(--form-control-size-md-padding);
-      font-size: var(--form-control-size-md-font-size);
+      padding: calc(var(--form-control-size-md-padding) - 1px) 0;
     }
   }
 
   &.lg {
-    > input {
-      border-radius: var(--form-control-size-lg-border-radius);
-      padding: calc(var(--form-control-size-lg-padding) - 1px) var(--form-control-size-lg-padding);
-      font-size: var(--form-control-size-lg-font-size);
-    }
+    border-radius: var(--form-control-size-lg-border-radius);
+    padding: calc(var(--form-control-size-lg-padding) - 1px) var(--form-control-size-lg-padding);
+    font-size: var(--form-control-size-lg-font-size);
   }
 
   &.error {
-    > input {
-      border-color: var(--form-control-error-border-color);
-      background-color: var(--form-control-error-background-color);
+    border-color: var(--form-control-error-border-color);
+    background-color: var(--form-control-error-background-color);
 
-      &:focus {
-        outline: none;
-        border-color: var(--form-control-focus-border-color);
-        background-color: var(--form-control-background-color);
-      }
+    input:focus {
+      outline: none;
+      border-color: var(--form-control-focus-border-color);
+      background-color: transparent;
     }
   }
 
   .clear-button {
     /* Reset default button styles */
-    position: absolute;
-    top: 50%;
-    right: 12px;
-    transform: translateY(-50%);
     border: 0;
     background: none;
     cursor: pointer;

--- a/src/components/TextInput/TextInput.stories.mdx
+++ b/src/components/TextInput/TextInput.stories.mdx
@@ -152,8 +152,8 @@ All that is required to render a basic version of the TextInput is a unique `id`
       const [value2, setValue2] = useState('');
       const [value3, setValue3] = useState('Pre-populated Value');
       return (
-        <Box childGap="lg" direction="row">
-          <Box childGap="md" maxWidth="3xl">
+        <Box childGap="xl" direction="row">
+          <Box childGap="md" width="33">
             <TextInput
               id="prefix1"
               value={prefixValue}
@@ -191,7 +191,7 @@ All that is required to render a basic version of the TextInput is a unique `id`
               size="sm"
             />
           </Box>
-          <Box childGap="md" maxWidth="3xl">
+          <Box childGap="md" width="33">
             <TextInput
               id="prefix2"
               value={prefixValue}
@@ -225,7 +225,7 @@ All that is required to render a basic version of the TextInput is a unique `id`
               suffix={<Icon name="search" />}
             />
           </Box>
-          <Box childGap="md" maxWidth="3xl">
+          <Box childGap="md" width="33">
             <TextInput
               id="prefix3"
               value={prefixValue}

--- a/src/components/TextInput/TextInput.stories.mdx
+++ b/src/components/TextInput/TextInput.stories.mdx
@@ -3,6 +3,7 @@ import { action } from '@storybook/addon-actions';
 import { Meta, Story, Canvas, ArgsTable } from '@storybook/addon-docs/blocks';
 import TextInput from './TextInput';
 import Box from '../Box/Box';
+import Icon from '../Icon/Icon';
 
 <Meta title="Components/Form Inputs/TextInput" component={TextInput} />
 
@@ -139,6 +140,135 @@ Use the `hideLabel` prop to not render the label.
   </Story>
 </Canvas>
 
+## Prefix and Suffix
+
+All that is required to render a basic version of the TextInput is a unique `id`, `label`, `value`, and an onchange event handler passed to the `onChange` prop.
+
+<Canvas>
+  <Story name="with prefix and suffix">
+    {() => {
+      const [prefixValue, setPrefixValue] = useState('palmettosolar');
+      const [value, setValue] = useState('49');
+      const [value2, setValue2] = useState('');
+      const [value3, setValue3] = useState('Pre-populated Value');
+      return (
+        <Box childGap="lg" direction="row">
+          <Box childGap="md" maxWidth="3xl">
+            <TextInput
+              id="prefix1"
+              value={prefixValue}
+              label="Prefix"
+              onChange={event => setPrefixValue(event.target.value)}
+              prefix="@"
+              size="sm"
+            />
+            <TextInput
+              id="prefixSuffix1"
+              value={value}
+              label="Prefix and Suffix"
+              onChange={event => setValue(event.target.value)}
+              prefix="$"
+              suffix=".99"
+              size="sm"
+            />
+            <TextInput
+              id="prefixSuffix2"
+              value={value2}
+              label="Suffix"
+              placeholder="Contact name"
+              onChange={event => setValue2(event.target.value)}
+              suffix={<Icon name="book" />}
+              size="sm"
+            />
+            <TextInput
+              id="prefixSuffix3"
+              value={value3}
+              label="Suffix with Clear"
+              placeholder="Contact name"
+              onChange={event => setValue3(event.target.value)}
+              onClear={event => setValue3('')}
+              suffix={<Icon name="search" />}
+              size="sm"
+            />
+          </Box>
+          <Box childGap="md" maxWidth="3xl">
+            <TextInput
+              id="prefix2"
+              value={prefixValue}
+              label="Prefix"
+              onChange={event => setPrefixValue(event.target.value)}
+              prefix="@"
+            />
+            <TextInput
+              id="prefixSuffix4"
+              value={value}
+              label="Prefix and Suffix"
+              onChange={event => setValue(event.target.value)}
+              prefix="$"
+              suffix=".99"
+            />
+            <TextInput
+              id="prefixSuffix5"
+              value={value2}
+              label="Suffix"
+              placeholder="Contact name"
+              onChange={event => setValue2(event.target.value)}
+              suffix={<Icon name="book" />}
+            />
+            <TextInput
+              id="prefixSuffix6"
+              value={value3}
+              label="Suffix with Clear"
+              placeholder="Contact name"
+              onChange={event => setValue3(event.target.value)}
+              onClear={event => setValue3('')}
+              suffix={<Icon name="search" />}
+            />
+          </Box>
+          <Box childGap="md" maxWidth="3xl">
+            <TextInput
+              id="prefix3"
+              value={prefixValue}
+              label="Prefix"
+              onChange={event => setPrefixValue(event.target.value)}
+              prefix="@"
+              size="lg"
+            />
+            <TextInput
+              id="prefixSuffix7"
+              value={value}
+              label="Prefix and Suffix"
+              onChange={event => setValue(event.target.value)}
+              prefix="$"
+              suffix=".99"
+              size="lg"
+            />
+            <TextInput
+              id="prefixSuffix8"
+              value={value2}
+              label="Suffix"
+              placeholder="Contact name"
+              onChange={event => setValue2(event.target.value)}
+              suffix={<Icon name="book" />}
+              size="lg"
+            />
+            <TextInput
+              id="prefixSuffix9"
+              value={value3}
+              label="Suffix with Clear"
+              placeholder="Contact name"
+              onChange={event => setValue3(event.target.value)}
+              onClear={event => setValue3('')}
+              suffix={<Icon name="search" />}
+              size="lg"
+            />
+          </Box>
+        </Box>
+      );
+    }}
+  </Story>
+</Canvas>
+
 ## Disabled
 
 Use the `isDisabled` prop to mark the input as disabled.
@@ -226,7 +356,6 @@ a callback function when the clear icon is clicked, which can then be handled to
   </Story>
 </Canvas>
 
-
 ## Sizes
 
 Set the size of the text input to `sm`, `md` or `lg`. `md` is the default size.
@@ -251,20 +380,20 @@ Set the size of the text input to `sm`, `md` or `lg`. `md` is the default size.
           width="100%"
         >
           <TextInput
-            id="default"
+            id="sizeSmall"
             value={value}
             label="Small Size"
             size="sm"
             onChange={event => setValue(event.target.value)}
           />
           <TextInput
-            id="default"
+            id="sizeMedium"
             value={value1}
             label="Medium Size"
             onChange={event => setValue1(event.target.value)}
           />
           <TextInput
-            id="default"
+            id="sizeLarge"
             value={value2}
             label="Large Size"
             size="lg"
@@ -275,7 +404,6 @@ Set the size of the text input to `sm`, `md` or `lg`. `md` is the default size.
     }}
   </Story>
 </Canvas>
-
 
 ## With Phone Mask
 
@@ -456,19 +584,15 @@ Use the `className` prop to add a custom class, or classes to an input.
       const [value2, setValue2] = useState('');
       const [value3, setValue3] = useState('');
       return (
-        <Box
-          display="flex"
-          direction="row"
-          justify="between"
-          overflow="hidden"
-          childGap="md"
-        >
+        <Box display="flex" direction="row" justify="between" overflow="hidden" childGap="md">
           <TextInput
+            id="adjacent1"
             value={value1}
             label="input 1"
             onChange={event => setValue1(event.target.value)}
           />
           <TextInput
+            id="adjacent2"
             value={value2}
             label="input 2"
             onChange={event => setValue2(event.target.value)}

--- a/src/components/TextInput/TextInput.stories.mdx
+++ b/src/components/TextInput/TextInput.stories.mdx
@@ -145,124 +145,46 @@ Use the `hideLabel` prop to not render the label.
 All that is required to render a basic version of the TextInput is a unique `id`, `label`, `value`, and an onchange event handler passed to the `onChange` prop.
 
 <Canvas>
-  <Story name="with prefix and suffix">
+  <Story name="With Prefix and Suffix">
     {() => {
-      const [prefixValue, setPrefixValue] = useState('palmettosolar');
-      const [value, setValue] = useState('49');
-      const [value2, setValue2] = useState('');
-      const [value3, setValue3] = useState('Pre-populated Value');
+      const [prefixValue1, setPrefixValue1] = useState('palmettosolar');
+      const [prefixValue2, setPrefixValue2] = useState('49');
+      const [prefixValue3, setPrefixValue3] = useState('');
+      const [prefixValue4, setPrefixValue4] = useState('Pre-populated Value');
       return (
-        <Box childGap="xl" direction="row">
-          <Box childGap="md" width="33">
-            <TextInput
-              id="prefix1"
-              value={prefixValue}
-              label="Prefix"
-              onChange={event => setPrefixValue(event.target.value)}
-              prefix="@"
-              size="sm"
-            />
-            <TextInput
-              id="prefixSuffix1"
-              value={value}
-              label="Prefix and Suffix"
-              onChange={event => setValue(event.target.value)}
-              prefix="$"
-              suffix=".99"
-              size="sm"
-            />
-            <TextInput
-              id="prefixSuffix2"
-              value={value2}
-              label="Suffix"
-              placeholder="Contact name"
-              onChange={event => setValue2(event.target.value)}
-              suffix={<Icon name="book" />}
-              size="sm"
-            />
-            <TextInput
-              id="prefixSuffix3"
-              value={value3}
-              label="Suffix with Clear"
-              placeholder="Contact name"
-              onChange={event => setValue3(event.target.value)}
-              onClear={event => setValue3('')}
-              suffix={<Icon name="search" />}
-              size="sm"
-            />
-          </Box>
-          <Box childGap="md" width="33">
-            <TextInput
-              id="prefix2"
-              value={prefixValue}
-              label="Prefix"
-              onChange={event => setPrefixValue(event.target.value)}
-              prefix="@"
-            />
-            <TextInput
-              id="prefixSuffix4"
-              value={value}
-              label="Prefix and Suffix"
-              onChange={event => setValue(event.target.value)}
-              prefix="$"
-              suffix=".99"
-            />
-            <TextInput
-              id="prefixSuffix5"
-              value={value2}
-              label="Suffix"
-              placeholder="Contact name"
-              onChange={event => setValue2(event.target.value)}
-              suffix={<Icon name="book" />}
-            />
-            <TextInput
-              id="prefixSuffix6"
-              value={value3}
-              label="Suffix with Clear"
-              placeholder="Contact name"
-              onChange={event => setValue3(event.target.value)}
-              onClear={event => setValue3('')}
-              suffix={<Icon name="search" />}
-            />
-          </Box>
-          <Box childGap="md" width="33">
-            <TextInput
-              id="prefix3"
-              value={prefixValue}
-              label="Prefix"
-              onChange={event => setPrefixValue(event.target.value)}
-              prefix="@"
-              size="lg"
-            />
-            <TextInput
-              id="prefixSuffix7"
-              value={value}
-              label="Prefix and Suffix"
-              onChange={event => setValue(event.target.value)}
-              prefix="$"
-              suffix=".99"
-              size="lg"
-            />
-            <TextInput
-              id="prefixSuffix8"
-              value={value2}
-              label="Suffix"
-              placeholder="Contact name"
-              onChange={event => setValue2(event.target.value)}
-              suffix={<Icon name="book" />}
-              size="lg"
-            />
-            <TextInput
-              id="prefixSuffix9"
-              value={value3}
-              label="Suffix with Clear"
-              placeholder="Contact name"
-              onChange={event => setValue3(event.target.value)}
-              onClear={event => setValue3('')}
-              suffix={<Icon name="search" />}
-              size="lg"
-            />
-          </Box>
+        <Box childGap="md" display="block">
+          <TextInput
+            id="prefixSuffix1"
+            value={prefixValue1}
+            label="Prefix"
+            onChange={event => setPrefixValue1(event.target.value)}
+            prefix="@"
+          />
+          <TextInput
+            id="prefixSuffix2"
+            value={prefixValue2}
+            label="Prefix and Suffix"
+            onChange={event => setPrefixValue2(event.target.value)}
+            prefix="$"
+            suffix=".99"
+          />
+          <TextInput
+            id="prefixSuffix3"
+            value={prefixValue3}
+            label="Suffix"
+            placeholder="Contact name"
+            onChange={event => setPrefixValue3(event.target.value)}
+            suffix={<Icon name="book" />}
+          />
+          <TextInput
+            id="prefixSuffix4"
+            value={prefixValue4}
+            label="Suffix with Clear"
+            placeholder="Contact name"
+            onChange={event => setPrefixValue4(event.target.value)}
+            onClear={event => setPrefixValue4('')}
+            suffix={<Icon name="search" />}
+          />
         </Box>
       );
     }}

--- a/src/components/TextInput/TextInput.stories.tsx
+++ b/src/components/TextInput/TextInput.stories.tsx
@@ -1,0 +1,130 @@
+import React, { ReactElement, useState } from 'react';
+import TextInput from './TextInput';
+import Icon from '../Icon/Icon';
+import Box from '../Box/Box';
+
+export default {
+  title: 'Components/Form Inputs/TextInput/For Chromatic',
+  component: TextInput,
+};
+
+export const PrefixSuffixSizes: React.FC = (): ReactElement => {
+  const [prefixValue, setPrefixValue] = useState('palmettosolar');
+  const [prefixValue2, setPrefixValue2] = useState('49');
+  const [prefixValue3, setPrefixValue3] = useState('');
+  const [prefixValue4, setPrefixValue4] = useState('Pre-populated Value');
+  return (
+    <Box childGap="xl" direction="row">
+      <Box childGap="md" width="33">
+        <TextInput
+          id="prefixSuffix1"
+          value={prefixValue}
+          label="Prefix"
+          onChange={event => setPrefixValue(event.target.value)}
+          prefix="@"
+          size="sm"
+        />
+        <TextInput
+          id="prefixSuffix2"
+          value={prefixValue2}
+          label="Prefix and Suffix"
+          onChange={event => setPrefixValue2(event.target.value)}
+          prefix="$"
+          suffix=".99"
+          size="sm"
+        />
+        <TextInput
+          id="prefixSuffix3"
+          value={prefixValue3}
+          label="Suffix"
+          placeholder="Contact name"
+          onChange={event => setPrefixValue3(event.target.value)}
+          suffix={<Icon name="book" />}
+          size="sm"
+        />
+        <TextInput
+          id="prefixSuffix4"
+          value={prefixValue4}
+          label="Suffix with Clear"
+          placeholder="Contact name"
+          onChange={event => setPrefixValue4(event.target.value)}
+          onClear={() => setPrefixValue4('')}
+          suffix={<Icon name="search" />}
+          size="sm"
+        />
+      </Box>
+      <Box childGap="md" width="33">
+        <TextInput
+          id="prefixSuffix5"
+          value={prefixValue}
+          label="Prefix"
+          onChange={event => setPrefixValue(event.target.value)}
+          prefix="@"
+        />
+        <TextInput
+          id="prefixSuffix6"
+          value={prefixValue2}
+          label="Prefix and Suffix"
+          onChange={event => setPrefixValue2(event.target.value)}
+          prefix="$"
+          suffix=".99"
+        />
+        <TextInput
+          id="prefixSuffix7"
+          value={prefixValue3}
+          label="Suffix"
+          placeholder="Contact name"
+          onChange={event => setPrefixValue3(event.target.value)}
+          suffix={<Icon name="book" />}
+        />
+        <TextInput
+          id="prefixSuffix8"
+          value={prefixValue4}
+          label="Suffix with Clear"
+          placeholder="Contact name"
+          onChange={event => setPrefixValue4(event.target.value)}
+          onClear={() => setPrefixValue4('')}
+          suffix={<Icon name="search" />}
+        />
+      </Box>
+      <Box childGap="md" width="33">
+        <TextInput
+          id="prefixSuffix9"
+          value={prefixValue}
+          label="Prefix"
+          onChange={event => setPrefixValue(event.target.value)}
+          prefix="@"
+          size="lg"
+        />
+        <TextInput
+          id="prefixSuffix10"
+          value={prefixValue2}
+          label="Prefix and Suffix"
+          onChange={event => setPrefixValue2(event.target.value)}
+          prefix="$"
+          suffix=".99"
+          size="lg"
+        />
+        <TextInput
+          id="prefixSuffix11"
+          value={prefixValue3}
+          label="Suffix"
+          placeholder="Contact name"
+          onChange={event => setPrefixValue3(event.target.value)}
+          suffix={<Icon name="book" />}
+          size="lg"
+        />
+        <TextInput
+          id="prefixSuffix112"
+          value={prefixValue4}
+          label="Suffix with Clear"
+          placeholder="Contact name"
+          onChange={event => setPrefixValue4(event.target.value)}
+          onClear={() => setPrefixValue4('')}
+          suffix={<Icon name="search" />}
+          size="lg"
+        />
+      </Box>
+    </Box>
+  );
+};

--- a/src/components/TextInput/TextInput.test.tsx
+++ b/src/components/TextInput/TextInput.test.tsx
@@ -1,9 +1,5 @@
 import React from 'react';
-import {
-  render,
-  fireEvent,
-  screen,
-} from '@testing-library/react';
+import { render, fireEvent, screen } from '@testing-library/react';
 import TextInput from './TextInput';
 
 const baseProps = {
@@ -30,30 +26,55 @@ describe('TextInput', () => {
 
       test('onChange event fires callback function with masked input', () => {
         let value = '123';
-        const mockedHandleChange = jest.fn(event => { value = event.target.value; });
+        const mockedHandleChange = jest.fn(event => {
+          value = event.target.value;
+        });
 
         const { rerender } = render(
-          <TextInput {...baseProps} value={value} onChange={mockedHandleChange} inputMask="phone" />,
+          <TextInput
+            {...baseProps}
+            value={value}
+            onChange={mockedHandleChange}
+            inputMask="phone"
+          />,
         );
         const inputElement = screen.getByDisplayValue('(123)');
 
         fireEvent.change(inputElement, { target: { value: 'good bye' } });
         expect(mockedHandleChange).toHaveBeenCalledTimes(1);
 
-        rerender(<TextInput {...baseProps} value={value} onChange={mockedHandleChange} inputMask="phone" />);
+        rerender(
+          <TextInput
+            {...baseProps}
+            value={value}
+            onChange={mockedHandleChange}
+            inputMask="phone"
+          />,
+        );
         expect((inputElement as HTMLInputElement).value).toBe('');
 
         fireEvent.change(inputElement, { target: { value: '12381238' } });
         expect(mockedHandleChange).toHaveBeenCalledTimes(2);
 
-        rerender(<TextInput {...baseProps} value={value} onChange={mockedHandleChange} inputMask="phone" />);
+        rerender(
+          <TextInput
+            {...baseProps}
+            value={value}
+            onChange={mockedHandleChange}
+            inputMask="phone"
+          />,
+        );
         expect((inputElement as HTMLInputElement).value).toBe('(123) 812-38');
       });
 
       test('Input value is updated properly when upper state changes', () => {
         let value = 'hello';
-        const mockedHandleChange = jest.fn(event => { value = event.target.value; });
-        const { rerender } = render(<TextInput {...baseProps} value={value} onChange={mockedHandleChange} />);
+        const mockedHandleChange = jest.fn(event => {
+          value = event.target.value;
+        });
+        const { rerender } = render(
+          <TextInput {...baseProps} value={value} onChange={mockedHandleChange} />,
+        );
 
         const inputElement = screen.getByDisplayValue('hello') as HTMLInputElement;
         expect(inputElement.value).toBe('hello');
@@ -138,17 +159,13 @@ describe('TextInput', () => {
       });
 
       test('Input correctly assigns autocomplete value of "off" when bool false is provided', () => {
-        render(
-          <TextInput {...baseProps} autoComplete={false} />,
-        );
+        render(<TextInput {...baseProps} autoComplete={false} />);
         const inputElement = screen.getByDisplayValue('hello');
         expect(inputElement).toHaveAttribute('autocomplete', 'off');
       });
 
       test('Input correctly assigns autocomplete specific value when provided', () => {
-        render(
-          <TextInput {...baseProps} autoComplete="email" />,
-        );
+        render(<TextInput {...baseProps} autoComplete="email" />);
         const inputElement = screen.getByDisplayValue('hello');
         expect(inputElement).toHaveAttribute('autocomplete', 'email');
       });
@@ -163,7 +180,7 @@ describe('TextInput', () => {
         expect(inputElement).toHaveAttribute('aria-required', 'true');
       });
 
-      test('it\'s label renders an asterisk indicating that it\'s required', () => {
+      test("it's label renders an asterisk indicating that it's required", () => {
         render(<TextInput {...baseProps} isRequired />);
 
         const labelElement = screen.getByText(`${baseProps.label} *`);
@@ -193,9 +210,7 @@ describe('TextInput', () => {
 
     describe('Max Length', () => {
       test('Input correctly passes maxlength property if prop is passed', async () => {
-        render(
-          <TextInput {...baseProps} value="" maxLength={3} />,
-        );
+        render(<TextInput {...baseProps} value="" maxLength={3} />);
 
         const inputElement = screen.getByLabelText(baseProps.label);
         expect(inputElement).toBeInTheDocument();
@@ -217,15 +232,25 @@ describe('TextInput', () => {
         const inputElement = screen.getByLabelText(baseProps.label);
         expect(inputElement).not.toHaveAttribute('aria-labelledby');
       });
+
+      describe('Prefix and Suffix', () => {
+        test('renders the prefix if specified', () => {
+          render(<TextInput {...baseProps} prefix="prefixValue" />);
+          expect(screen.getByText('prefixValue')).toBeInTheDocument();
+        });
+
+        test('renders the suffix if specified', () => {
+          render(<TextInput {...baseProps} suffix="suffixValue" />);
+          expect(screen.getByText('suffixValue')).toBeInTheDocument();
+        });
+      });
     });
 
     // NOTE: due to an unknown bug in the Cleave implementation, we are unable to test change events,
     // but we can at least confirm that the component renders an input when an inputMask is passed.
     describe('Masked', () => {
       test('Properly renders an input when inputMask is passed', () => {
-        render(
-          <TextInput {...baseProps} inputMask="phone" placeholder="phone" />,
-        );
+        render(<TextInput {...baseProps} inputMask="phone" placeholder="phone" />);
         const inputElement = screen.getByPlaceholderText('phone');
         expect(inputElement).toBeInTheDocument();
       });

--- a/src/components/TextInput/TextInput.tsx
+++ b/src/components/TextInput/TextInput.tsx
@@ -96,9 +96,18 @@ export interface TextInputBaseProps {
    */
   placeholder?: string;
   /**
+   * An input helper rendered before the input field value
+   */
+  prefix?: ReactNode;
+  /**
    * The size of the text input.
    */
   size?: 'sm' | 'md' | 'lg';
+
+  /**
+   * An input helper rendered after the input field value
+   */
+  suffix?: ReactNode;
   /**
    * The input 'type' value. Defaults to type 'text'.
    */
@@ -140,9 +149,11 @@ const TextInput: FC<TextInputProps> = forwardRef<HTMLInputElement & Component, T
       onBlur = undefined,
       onClear = undefined,
       onFocus = undefined,
+      prefix = undefined,
       placeholder = '',
-      type = 'text',
+      suffix = undefined,
       size = 'md',
+      type = 'text',
       ...restProps
     },
     ref,
@@ -186,6 +197,7 @@ const TextInput: FC<TextInputProps> = forwardRef<HTMLInputElement & Component, T
           onKeyUp={handleKeyPress}
           className={clearBtnClasses}
           data-testid="text-input-clear-button"
+          aria-label="clear input"
         >
           <Icon name="remove" className={styles['clear-icon']} />
         </button>
@@ -224,14 +236,24 @@ const TextInput: FC<TextInputProps> = forwardRef<HTMLInputElement & Component, T
     return (
       <Box width="100%" className={className}>
         {label && !hideLabel && <FormLabel {...labelProps}>{label}</FormLabel>}
-        <div className={inputWrapperClasses}>
+        <Box direction="row" className={inputWrapperClasses}>
+          {prefix && (
+            <Box justifyContent="center" color="grey-400" margin="0 xs 0 0">
+              {prefix}
+            </Box>
+          )}
           {!inputMask ? (
             <input {...inputProps} ref={ref} />
           ) : (
             <Cleave {...inputProps} options={getInputMask(inputMask, InputMasks)} />
           )}
           {!!onClear && !!value && renderClearIcon()}
-        </div>
+          {suffix && (
+            <Box justifyContent="center" color="grey-400" margin="0 0 0 xs">
+              {suffix}
+            </Box>
+          )}
+        </Box>
         {error && error !== true && <InputValidationMessage>{error}</InputValidationMessage>}
       </Box>
     );

--- a/src/components/TextInput/TextInput.tsx
+++ b/src/components/TextInput/TextInput.tsx
@@ -211,6 +211,11 @@ const TextInput: FC<TextInputProps> = forwardRef<HTMLInputElement & Component, T
       'aria-labelledby': label && !hideLabel ? `${id}Label` : undefined,
       autoComplete: getAutoCompleteValue(autoComplete),
       autoFocus,
+      className: classNames({
+        'p-left-xs': prefix,
+        'p-right-xs': suffix,
+        'p-h-0': !suffix && !prefix,
+      }),
       disabled: isDisabled,
       id,
       maxLength,
@@ -238,7 +243,7 @@ const TextInput: FC<TextInputProps> = forwardRef<HTMLInputElement & Component, T
         {label && !hideLabel && <FormLabel {...labelProps}>{label}</FormLabel>}
         <Box direction="row" className={inputWrapperClasses}>
           {prefix && (
-            <Box justifyContent="center" color="grey-400" margin="0 xs 0 0">
+            <Box justifyContent="center" color="grey-400">
               {prefix}
             </Box>
           )}
@@ -249,7 +254,7 @@ const TextInput: FC<TextInputProps> = forwardRef<HTMLInputElement & Component, T
           )}
           {!!onClear && !!value && renderClearIcon()}
           {suffix && (
-            <Box justifyContent="center" color="grey-400" margin="0 0 0 xs">
+            <Box justifyContent="center" color="grey-400">
               {suffix}
             </Box>
           )}

--- a/src/components/TextInput/TextInput.tsx
+++ b/src/components/TextInput/TextInput.tsx
@@ -242,22 +242,14 @@ const TextInput: FC<TextInputProps> = forwardRef<HTMLInputElement & Component, T
       <Box width="100%" className={className}>
         {label && !hideLabel && <FormLabel {...labelProps}>{label}</FormLabel>}
         <Box direction="row" className={inputWrapperClasses}>
-          {prefix && (
-            <Box justifyContent="center" color="grey-400">
-              {prefix}
-            </Box>
-          )}
+          {prefix && <Box color="grey-400">{prefix}</Box>}
           {!inputMask ? (
             <input {...inputProps} ref={ref} />
           ) : (
             <Cleave {...inputProps} options={getInputMask(inputMask, InputMasks)} />
           )}
           {!!onClear && !!value && renderClearIcon()}
-          {suffix && (
-            <Box justifyContent="center" color="grey-400">
-              {suffix}
-            </Box>
-          )}
+          {suffix && <Box color="grey-400">{suffix}</Box>}
         </Box>
         {error && error !== true && <InputValidationMessage>{error}</InputValidationMessage>}
       </Box>

--- a/src/components/TextInput/TextInput.tsx
+++ b/src/components/TextInput/TextInput.tsx
@@ -199,7 +199,7 @@ const TextInput: FC<TextInputProps> = forwardRef<HTMLInputElement & Component, T
           data-testid="text-input-clear-button"
           aria-label="clear input"
         >
-          <Icon name="remove" className={styles['clear-icon']} />
+          <Icon name="remove" className="display-block" />
         </button>
       );
     };

--- a/src/styles/variables/forms.scss
+++ b/src/styles/variables/forms.scss
@@ -60,6 +60,6 @@
 
   /* ----TEXT INPUT---- */
   --form-control-text-clear-icon-margin: var(--size-spacing-xs);
-  --form-control-text-clear-icon-font-size: var(--size-font-lg);
+  --form-control-text-clear-icon-font-size: var(--size-font-md);
   --form-control-text-line-height: var(--size-line-height-input);
 }


### PR DESCRIPTION
Doc example: 
<img width="278" alt="Screen Shot 2020-12-22 at 5 33 45 PM" src="https://user-images.githubusercontent.com/1447339/102948916-daf3a980-447b-11eb-9888-cadc7ef5c34c.png">

Created a separate "For Chromatic" stories file that has all permutations of sizes and prefix/suffix combinations for visual regression tests, without cluttering up the documentation.

<img width="986" alt="Screen Shot 2020-12-23 at 10 39 59 AM" src="https://user-images.githubusercontent.com/1447339/103027713-3c168e00-450b-11eb-96d7-e27085ed0c75.png">
