### PR TITLE
prevent TextInput prefix/suffix from wrapping into multiple lines

### DIFF
--- a/src/components/TextInput/TextInput.stories.mdx
+++ b/src/components/TextInput/TextInput.stories.mdx
@@ -166,7 +166,7 @@ All that is required to render a basic version of the TextInput is a unique `id`
             label="Prefix and Suffix"
             onChange={event => setPrefixValue2(event.target.value)}
             prefix="$"
-            suffix=".99"
+            suffix="per watt"
           />
           <TextInput
             id="prefixSuffix3"

--- a/src/components/TextInput/TextInput.tsx
+++ b/src/components/TextInput/TextInput.tsx
@@ -243,14 +243,22 @@ const TextInput: FC<TextInputProps> = forwardRef<HTMLInputElement & Component, T
       <Box width="100%" className={className}>
         {label && !hideLabel && <FormLabel {...labelProps}>{label}</FormLabel>}
         <Box direction="row" className={inputWrapperClasses}>
-          {prefix && <Box color="grey-400">{prefix}</Box>}
+          {prefix && (
+            <Box color="grey-400" className="ws-nowrap">
+              {prefix}
+            </Box>
+          )}
           {!inputMask ? (
             <input {...inputProps} ref={ref} />
           ) : (
             <Cleave {...inputProps} options={getInputMask(inputMask, InputMasks)} />
           )}
           {!!onClear && !!value && renderClearIcon()}
-          {suffix && <Box color="grey-400">{suffix}</Box>}
+          {suffix && (
+            <Box color="grey-400" className="ws-nowrap">
+              {suffix}
+            </Box>
+          )}
         </Box>
         {error && error !== true && <InputValidationMessage>{error}</InputValidationMessage>}
       </Box>

--- a/src/styles/utilities.scss
+++ b/src/styles/utilities.scss
@@ -3,3 +3,4 @@
 @import './flex';
 @import './overflow';
 @import './text-align';
+@import './white-space';

--- a/src/styles/white-space.scss
+++ b/src/styles/white-space.scss
@@ -1,0 +1,22 @@
+
+.ws-normal { white-space: normal; }
+.ws-nowrap { white-space: nowrap; }
+.ws-pre { white-space: pre; }
+
+@media (min-width: $size-breakpoint-tablet) {
+  .ws-normal-tablet { white-space: normal; }
+  .ws-nowrap-tablet { white-space: nowrap; }
+  .ws-pre-tablet { white-space: pre; }
+}
+
+@media (min-width: $size-breakpoint-desktop) {
+  .ws-normal-desktop { white-space: normal; }
+  .ws-nowrap-desktop { white-space: nowrap; }
+  .ws-pre-desktop { white-space: pre; }
+}
+
+@media (min-width: $size-breakpoint-hd) {
+  .ws-normal-hd { white-space: normal; }
+  .ws-nowrap-hd { white-space: nowrap; }
+  .ws-pre-hd { white-space: pre; }
+}


### PR DESCRIPTION
1.  white-space css utility classes
1.  fixes prefix/suffix wrapping. currently if a prefix or suffix value is multiple words, it can wrap depending on the TextInput container size, causing an input to look like:
  <img width="162" alt="Screen Shot 2021-01-11 at 3 48 59 PM" src="https://user-images.githubusercontent.com/1447339/104251418-87460180-5424-11eb-84c6-795c440e57d9.png">
  after: 
  <img width="154" alt="Screen Shot 2021-01-11 at 3 49 46 PM" src="https://user-images.githubusercontent.com/1447339/104251468-a349a300-5424-11eb-9234-f5ad07cad950.png">
