### PR TITLE
fix(Button): update hover state appearance of isOutlined Buttons

### DIFF
--- a/src/components/Button/Button.module.scss
+++ b/src/components/Button/Button.module.scss
@@ -161,14 +161,14 @@
     }
 
     &.outline {
-      border-color: var(--button-border-hover-color-dark-outline);
+      border-color: var(--button-border-color-dark-outline);
       background-color: transparent;
       color: var(--button-font-color-dark-outline);
 
       &:hover {
         border-color: var(--button-border-hover-color-dark-outline);
-        background-color: var(--button-background-hover-color-dark-outline);
-        color: var(--button-font-hover-color-dark-outline);
+        background-color: var(--color-brand-grey-50);
+        color: var(--button-font-color-dark-outline);
       }
     }
   }
@@ -197,13 +197,13 @@
     }
 
     &.outline {
-      border-color: var(--button-border-hover-color-light-outline);
+      border-color: var(--button-border-color-light-outline);
       background-color: transparent;
       color: var(--button-font-color-light-outline);
 
       &:hover {
         border-color: var(--button-border-hover-color-light-outline);
-        background-color: var(--button-background-hover-color-light-outline);
+        background-color: var(--color-brand-grey-50);
         color: var(--button-font-hover-color-light-outline);
       }
     }

--- a/src/styles/variables/buttons.scss
+++ b/src/styles/variables/buttons.scss
@@ -38,8 +38,8 @@
   --button-background-color-primary-outline: transparent;
   --button-font-color-primary-outline: var(--color-brand-primary-base);
   --button-border-hover-color-primary-outline: var(--color-brand-primary-base);
-  --button-background-hover-color-primary-outline: var(--color-brand-primary-base);
-  --button-font-hover-color-primary-outline: var(--color-brand-white-base);
+  --button-background-hover-color-primary-outline: var(--color-brand-primary-50);
+  --button-font-hover-color-primary-outline: var(--color-brand-primary-600);
 
   /* SUCCESS */
   --button-background-color-success: var(--color-brand-success-base);
@@ -50,8 +50,8 @@
   --button-background-color-success-outline: transparent;
   --button-font-color-success-outline: var(--color-brand-success-base);
   --button-border-hover-color-success-outline: var(--color-brand-success-base);
-  --button-background-hover-color-success-outline: var(--color-brand-success-base);
-  --button-font-hover-color-success-outline: var(--color-brand-white-base);
+  --button-background-hover-color-success-outline: var(--color-brand-success-50);
+  --button-font-hover-color-success-outline: var(--color-brand-success-600);
 
   /* DANGER */
   --button-background-color-danger: var(--color-brand-danger-base);
@@ -62,8 +62,8 @@
   --button-background-color-danger-outline: transparent;
   --button-font-color-danger-outline: var(--color-brand-danger-base);
   --button-border-hover-color-danger-outline: var(--color-brand-danger-base);
-  --button-background-hover-color-danger-outline: var(--color-brand-danger-base);
-  --button-font-hover-color-danger-outline: var(--color-brand-white-base);
+  --button-background-hover-color-danger-outline: var(--color-brand-danger-50);
+  --button-font-hover-color-danger-outline: var(--color-brand-danger-600);
   --button-focus-box-shadow-danger: 0 0 0 4px var(--color-brand-danger-lighter);
 
   /* LIGHT */
@@ -71,10 +71,10 @@
   --button-font-color-light: var(--color-brand-dark-base);
   --button-background-hover-color-light: var(--color-brand-grey-200);
 
-  --button-border-color-light-outline: var(--color-brand-light-base);
+  --button-border-color-light-outline: var(--color-brand-grey-200);
   --button-background-color-light-outline: transparent;
   --button-font-color-light-outline: var(--color-brand-dark-base);
-  --button-border-hover-color-light-outline: var(--color-brand-light-base);
+  --button-border-hover-color-light-outline: var(--color-brand-grey-400);
   --button-background-hover-color-light-outline: var(--color-brand-light-base);
   --button-font-hover-color-light-outline: var(--color-brand-dark-base);
   --button-focus-box-shadow-light: 0 0 0 4px var(--color-brand-grey-300);
@@ -87,7 +87,7 @@
   --button-border-color-dark-outline: var(--color-brand-dark-base);
   --button-background-color-dark-outline: transparent;
   --button-font-color-dark-outline: var(--color-brand-dark-base);
-  --button-border-hover-color-dark-outline: var(--color-brand-dark-base);
+  --button-border-hover-color-dark-outline: var(--color-brand-grey-900);
   --button-background-hover-color-dark-outline: var(--color-brand-dark-base);
   --button-font-hover-color-dark-outline: var(--color-brand-white-base);
   --button-focus-box-shadow-dark: 0 0 0 4px var(--color-brand-grey-200);

--- a/src/styles/variables/buttons.scss
+++ b/src/styles/variables/buttons.scss
@@ -71,7 +71,7 @@
   --button-font-color-light: var(--color-brand-dark-base);
   --button-background-hover-color-light: var(--color-brand-grey-200);
 
-  --button-border-color-light-outline: var(--color-brand-grey-200);
+  --button-border-color-light-outline: var(--color-brand-light-base);
   --button-background-color-light-outline: transparent;
   --button-font-color-light-outline: var(--color-brand-dark-base);
   --button-border-hover-color-light-outline: var(--color-brand-grey-400);


### PR DESCRIPTION
Currently when hovering over an `isOutlined` button, it turns into a "solid" looking button. This code change updates the hover state appearance of `isOutlined` buttons so that it maintains an "outlined" appearance on hover.

Current:

https://user-images.githubusercontent.com/1447339/108289582-826f1e80-7143-11eb-9900-ad3b39e2d792.mov

Current in example:

https://user-images.githubusercontent.com/1447339/108289701-c4986000-7143-11eb-90f7-88c137ff38dc.mov

After:

https://user-images.githubusercontent.com/1447339/108289712-c95d1400-7143-11eb-905f-da62230dae46.mov

After in example

https://user-images.githubusercontent.com/1447339/108289766-e42f8880-7143-11eb-9680-e6bfd9839154.mov

