### PR TITLE
fix(Icon): prevent empty class property from being added to svg element

### DIFF
--- a/src/components/Icon/Icon.test.tsx
+++ b/src/components/Icon/Icon.test.tsx
@@ -9,6 +9,18 @@ describe('Icon', () => {
     expect(icon).toBeInTheDocument();
   });
 
+  test('does not add a class property if none is provided', () => {
+    render(<Icon name="user" />);
+    const icon = screen.getByTestId('icon-testid--user');
+    expect(icon).not.toHaveAttribute('class');
+  });
+
+  test('adds a class property if defined', () => {
+    render(<Icon name="user" className="testClass" />);
+    const icon = screen.getByTestId('icon-testid--user');
+    expect(icon.getAttribute('class')).toBe('testClass');
+  });
+
   test('fallback', () => {
     render(<Icon name={'does-not-exist' as 'user'} />);
     const icon = screen.getByText('???');

--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -44,7 +44,7 @@ const Icon: FC<IconProps> = forwardRef<SVGSVGElement, IconProps>(
 
     return IconComponent ? (
       <IconComponent
-        className={iconClasses}
+        className={iconClasses || null}
         ref={ref}
         data-testid={`icon-testid--${name}`}
         {...restProps}


### PR DESCRIPTION
currently, Icon svgs are getting rendered with an empty `class` property instead of without one. 

<img width="395" alt="Screen Shot 2021-03-02 at 5 12 02 PM" src="https://user-images.githubusercontent.com/1447339/109737160-6a9f8d80-7b7a-11eb-88df-08cc842d663a.png">


This change prevents empty `class` property from being added to the svg.