### PR TITLE
fix(DateInput): Make date input read only.

### DIFF
--- a/src/components/DateInput/DateInput.Overview.stories.mdx
+++ b/src/components/DateInput/DateInput.Overview.stories.mdx
@@ -10,6 +10,8 @@ import Heading from '../Heading/Heading';
 
 Use a DateInput to allow users to select a date close to today and place that date in an input field.
 Avoid using this component if the user needs to enter a date that is many years in the past (i.e. birthday) or future.
+For entering these types of dates we recommend using the `TextInput` component with a `date` mask. See an example here:
+[TextInput Date Example](?path=/docs/components-textinput-overview--with-date-mask)
 
 <Canvas isExpanded>
   <DateInput
@@ -32,7 +34,7 @@ The DateInput is composed of 3 components. Each can be tailored based on their p
 
 1. [DatePicker](?path=/docs/components-datepicker--default-story)
 2. [Popover](?path=/docs/components-popover--demo)
-3. [TextInput](http://localhost:6006/?path=/docs/components-form-inputs-textinput--default-story)
+3. [TextInput](?path=/docs/components-textinput-overview--default-story)
 
 The `DateInput` uses sensible defaults for these to allow for very straightforward ergonomics that allow users to
 select dates with minimal work.

--- a/src/components/DateInput/DateInput.tsx
+++ b/src/components/DateInput/DateInput.tsx
@@ -143,6 +143,7 @@ const DateInput: FC<DateInputProps> = ({
         onClick={() => handleTogglePopover(true)}
         ref={textInputRef}
         onBlur={handleBlur}
+        readOnly
         {...restProps}
       />
     </Popover>

--- a/src/components/Popover/Popover.stories.mdx
+++ b/src/components/Popover/Popover.stories.mdx
@@ -191,7 +191,7 @@ items, however are fully customizable.
 
 ## Popover Styling
 
-Because the rendered Popover is powered by our `Box` component ([Read More](/?path=/docs/components-popover--page)) you
+Because the rendered Popover is powered by our `Box` component ([Read More](/?path=/docs/components-box-overview--background)) you
 can use all known box props to style it. The below example includes some of the basics, but is not representative of
 the entire gamut of styling options.
 

--- a/src/components/RadioGroup/RadioGroup.Overview.stories.mdx
+++ b/src/components/RadioGroup/RadioGroup.Overview.stories.mdx
@@ -13,7 +13,7 @@ import RadioGroup from './RadioGroup';
 
 # RadioGroup
 
-Use a RadioGroup when a user is required to select one of five or fewer options. It is ideal for this scenario because the options are displayed without having to interact. If there are more than five options, use the [SelectInput](?path=/docs/components-form-inputs-selectinput--default-story) instead.
+Use a RadioGroup when a user is required to select one of five or fewer options. It is ideal for this scenario because the options are displayed without having to interact. If there are more than five options, use the [SelectInput](?path=/docs/components-selectinput-overview--default-story) instead.
 
 ## Props
 

--- a/src/components/TextInput/TextInput.Overview.stories.mdx
+++ b/src/components/TextInput/TextInput.Overview.stories.mdx
@@ -381,6 +381,29 @@ Use the `type` prop to mark the input type as "tel". Use the `inputMask` prop to
   </Story>
 </Canvas>
 
+## With Date Mask
+
+Use the `type` prop to mark the input type as "tel". Use the `inputMask` prop to set the mask as "date".
+
+<Canvas>
+  <Story name="With Date Mask">
+    {() => {
+      const [value, setValue] = useState('');
+      return (
+        <TextInput
+          id="withDateMask"
+          value={value}
+          label="Label"
+          onChange={event => setValue(event.target.value)}
+          inputMask="date"
+          type="tel"
+          placeholder="MM-DD-YYYY"
+        />
+      );
+    }}
+  </Story>
+</Canvas>
+
 ## Max Length
 
 Use the `maxLength` prop to limit the number of characters that can be entered into an input.

--- a/src/components/TextInput/TextInput.tsx
+++ b/src/components/TextInput/TextInput.tsx
@@ -170,6 +170,11 @@ const TextInput: FC<TextInputProps> = forwardRef<HTMLInputElement & Component, T
         creditCard: {
           creditCard: boolean;
         };
+        date: {
+          date: boolean;
+          delimiter: string;
+          datePattern: string[];
+        }
       },
     ) => {
       if (typeof mask === 'string') {

--- a/src/components/TextInput/TextInput.tsx
+++ b/src/components/TextInput/TextInput.tsx
@@ -20,7 +20,7 @@ import InputValidationMessage from '../InputValidationMessage/InputValidationMes
 import getAutoCompleteValue from '../../lib/getAutoCompleteValue';
 import styles from './TextInput.module.scss';
 
-type inputMaskType = ('phone' | 'creditCard') | UnknownPropertiesObjType;
+type inputMaskType = ('phone' | 'creditCard' | 'date') | UnknownPropertiesObjType;
 
 export interface TextInputBaseProps {
   /**

--- a/src/components/TextInput/TextInput.tsx
+++ b/src/components/TextInput/TextInput.tsx
@@ -174,7 +174,7 @@ const TextInput: FC<TextInputProps> = forwardRef<HTMLInputElement & Component, T
           date: boolean;
           delimiter: string;
           datePattern: string[];
-        }
+        };
       },
     ) => {
       if (typeof mask === 'string') {

--- a/src/components/TextInput/TextInputMasks.js
+++ b/src/components/TextInput/TextInputMasks.js
@@ -7,3 +7,9 @@ export const phone = {
 export const creditCard = {
   creditCard: true,
 };
+
+export const date = {
+  date: true,
+  delimiter: '-',
+  datePattern: ['m', 'd', 'Y'],
+};

--- a/src/components/TimePicker/TimePicker.Overview.stories.mdx
+++ b/src/components/TimePicker/TimePicker.Overview.stories.mdx
@@ -16,7 +16,7 @@ import Box from '../Box/Box';
 
 Use a TimePicker when you want users to select from a list of a available times agnostic of date.
 
-_NOTE:_ This component is abstracted from the [SelectInput](?path=/docs/components-form-inputs-selectinput--default-story)
+_NOTE:_ This component is abstracted from the [SelectInput](?path=/docs/components-selectinput-overview--default-story)
 and as such includes the same underlying props interface with an added method for generating the time options automatically.
 
 _ABOUT TIME FORMAT:_ While the `value` prop technically returns `{ label: string; value: string; }` the value returned will always


### PR DESCRIPTION
This PR addresses this issue:
https://github.com/palmetto/palmetto-components/issues/357

* we have made the dateinput readonly so that it does not trigger the mobile keyboard.
* we've added another default mask to allow for entering dates easily into a text input.
