### PR TITLE
fix: overflow utility class breakpoints

### DIFF
--- a/src/styles/overflow.scss
+++ b/src/styles/overflow.scss
@@ -7,7 +7,7 @@
 .overflow-initial { overflow: initial; }
 .overflow-unset { overflow: unset; }
 
-@media (min-width: var(--size-breakpoint-tablet)) {
+@media (min-width: $size-breakpoint-tablet) {
   .overflow-visible-tablet { overflow: visible; }
   .overflow-hidden-tablet { overflow: hidden; }
   .overflow-clip-tablet { overflow: clip; }
@@ -18,7 +18,7 @@
   .overflow-unset-tablet { overflow: unset; }
 }
 
-@media (min-width: var(--size-breakpoint-desktop)) {
+@media (min-width: $size-breakpoint-desktop) {
   .overflow-visible-desktop { overflow: visible; }
   .overflow-hidden-desktop { overflow: hidden; }
   .overflow-clip-desktop { overflow: clip; }
@@ -29,7 +29,7 @@
   .overflow-unset-desktop { overflow: unset; }
 }
 
-@media (min-width: var(--size-breakpoint-hd)) {
+@media (min-width: $size-breakpoint-hd) {
   .overflow-visible-hd { overflow: visible; }
   .overflow-hidden-hd { overflow: hidden; }
   .overflow-clip-hd { overflow: clip; }


### PR DESCRIPTION
# Github Issue or Trello Card

The responsive overflow classes weren't getting generated because we're using css vars when it's expecting scss.

 
# What type of change is this?
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Updating documentation.
- [ ] Updating deployment/build pipeline.

# Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

# UI Checklist
- [x] I have conducted visual UAT on my changes/features.
- [x] My solution works well on desktop, tablet, and mobile browsers.