### PR TITLE
add key to PageButton component

### DIFF
--- a/src/components/Pagination/Pagination.tsx
+++ b/src/components/Pagination/Pagination.tsx
@@ -149,7 +149,7 @@ export const Pagination: FC<PaginationProps> = ({
     );
 
     return pages.map(page => (
-      <PageButton {...page} />
+      <PageButton key={page.pageNumber} {...page} />
     ));
   };
 


### PR DESCRIPTION
# Github Issue or Trello Card
This PR addresses this issue: The Pagination component did not have keys on the list of PageButtons resulting in warnings
![image](https://user-images.githubusercontent.com/15142691/114065682-8a546080-9860-11eb-8d07-0edaafaf2381.png)

This adds the key prop to PageButton based on pageNumber

# What type of change is this?
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Updating documentation.
- [ ] Updating deployment/build pipeline.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

# UI Checklist
- [ ] I have conducted visual UAT on my changes/features.
- [ ] My solution works well on desktop, tablet, and mobile browsers.