### PR TITLE
fix(Toggle): prevent toggle track from shrinking

### DIFF
--- a/src/components/Toggle/Toggle.module.scss
+++ b/src/components/Toggle/Toggle.module.scss
@@ -30,6 +30,7 @@
   background-color: var(--color-brand-grey-200);
   cursor: pointer;
   padding: 2px;
+  min-width: 2.5rem;
   width: 2.5rem;
   height: var(--size-spacing-lg);
 
@@ -39,11 +40,13 @@
 }
 
 .track-sm {
+  min-width: 1.5rem;
   width: 1.5rem;
   height: var(--size-spacing-md);
 }
 
 .track-lg {
+  min-width: 3.5rem;
   width: 3.5rem;
   height: var(--size-spacing-xl);
 }


### PR DESCRIPTION
# Github Issue or Trello Card

Prevents the toggle track from shrinking when width of the toggle's parent container is narrow. For example:

![Screen Shot 2021-04-22 at 3 26 45 PM](https://user-images.githubusercontent.com/1447339/115792543-54929a00-a37f-11eb-9536-2e26a3f1a645.png)

Should look like
![Screen Shot 2021-04-22 at 3 29 02 PM](https://user-images.githubusercontent.com/1447339/115792630-7a1fa380-a37f-11eb-8cd2-670d7e5c0a65.png)


# What type of change is this?
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Updating documentation.
- [ ] Updating deployment/build pipeline.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

# UI Checklist
- [ ] I have conducted visual UAT on my changes/features.
- [ ] My solution works well on desktop, tablet, and mobile browsers.