### PR TITLE
perf(DictionarySize): refactor with smaller tokens dictionary format

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "files": [
     "dist"
   ],
+  "sideEffects": false,
   "repository": {
     "type": "git",
     "url": "https://github.com/palmetto/palmetto-components"
@@ -17,7 +18,7 @@
     "@fortawesome/fontawesome-svg-core": "^1.2.30",
     "@fortawesome/free-solid-svg-icons": "^5.14.0",
     "@fortawesome/react-fontawesome": "^0.1.11",
-    "@palmetto/palmetto-design-tokens": "0.37.0",
+    "@palmetto/palmetto-design-tokens": "0.38.1",
     "@popperjs/core": "^2.5.3",
     "@reach/dialog": "^0.11.2",
     "@types/cleave.js": "^1.4.3",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@fortawesome/fontawesome-svg-core": "^1.2.30",
     "@fortawesome/free-solid-svg-icons": "^5.14.0",
     "@fortawesome/react-fontawesome": "^0.1.11",
-    "@palmetto/palmetto-design-tokens": "0.38.1",
+    "@palmetto/palmetto-design-tokens": "0.38.2",
     "@popperjs/core": "^2.5.3",
     "@reach/dialog": "^0.11.2",
     "@types/cleave.js": "^1.4.3",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
   "files": [
     "dist"
   ],
-  "sideEffects": false,
   "repository": {
     "type": "git",
     "url": "https://github.com/palmetto/palmetto-components"

--- a/src/components/SelectInput/SelectInput.tsx
+++ b/src/components/SelectInput/SelectInput.tsx
@@ -195,7 +195,7 @@ export const SelectInput: FC<SelectInputProps> = ({
         onChange={handleChange}
         onFocus={handleFocus}
         onBlur={handleBlur}
-        styles={{ menuPortal: base => ({ ...base, zIndex: Number(Z_INDEX_VALUES.popover.value) }) }}
+        styles={{ menuPortal: base => ({ ...base, zIndex: Number(Z_INDEX_VALUES.popover) }) }}
         value={value}
       />
       {error && typeof error !== 'boolean' && (

--- a/src/components/Spinner/Spinner.tsx
+++ b/src/components/Spinner/Spinner.tsx
@@ -1,6 +1,6 @@
 import React, { FC } from 'react';
 import classNames from 'classnames';
-import { BRAND_COLORS } from '../../lib/tokens';
+import { BASE_BRAND_COLORS } from '../../lib/tokens';
 import { ColorName } from '../../types';
 import styles from './Spinner.module.scss';
 
@@ -42,9 +42,9 @@ export const Spinner: FC<SpinnerProps> = ({ variant = 'dark', className, size = 
         data-testid="spinner-testid"
       >
         <title>circle</title>
-        <g fill={`${BRAND_COLORS[variant].base.value}`}>
+        <g fill={`${BASE_BRAND_COLORS[variant]}`}>
           <path
-            fill={`${BRAND_COLORS[variant].base.value}`}
+            fill={`${BASE_BRAND_COLORS[variant]}`}
             d="M8,16c-1.199,0-2.352-0.259-3.428-0.77l0.857-1.807C6.235,13.806,7.1,14,8,14c3.309,0,6-2.691,6-6 s-2.691-6-6-6S2,4.691,2,8c0,0.901,0.194,1.766,0.578,2.572l-1.806,0.859C0.26,10.354,0,9.2,0,8c0-4.411,3.589-8,8-8s8,3.589,8,8 S12.411,16,8,16z" /* eslint-disable-line max-len */
           />
         </g>

--- a/src/docs/BorderRadius.stories.mdx
+++ b/src/docs/BorderRadius.stories.mdx
@@ -1,6 +1,5 @@
 import { Meta } from '@storybook/addon-docs/blocks';
-import sizes from '@palmetto/palmetto-design-tokens/build/js/variables-size';
-import { BORDER_RADIUS_OPTIONS, BORDER_RADIUS_VALUES } from '../lib/tokens';
+import { size } from '@palmetto/palmetto-design-tokens/build/js/variables-size';
 
 <Meta
   title="Design Tokens/Border Radius"
@@ -17,17 +16,15 @@ Use these tokens for `border-radius`. They are defined in `rem`, which means the
       <th>prop value</th>
       <th>value</th>
       <th>px</th>
-      <th>notes</th>
     </tr>
   </thead>
   <tbody>
-    {BORDER_RADIUS_OPTIONS.map((radius, i) => (
+    {Object.entries(size['border-radius']).map(([name, entry], i) => (
       <tr key={i}>
-        <td><code>{`size-border-radius-${radius}`}</code></td>
-        <td><code>{radius}</code></td>
-        <td>{BORDER_RADIUS_VALUES[i].value}</td>
-        <td>{radius !== 'circle' ? BORDER_RADIUS_VALUES[i].original.value * 16 : 'n/a'}</td>
-        <td>{BORDER_RADIUS_VALUES[i].original.comment}</td>
+        <td><code>{`size-border-radius-${name}`}</code></td>
+        <td><code>{name}</code></td>
+        <td>{entry.value}</td>
+        <td>{name !== 'circle' ? entry.original.value * 16 : ''}</td>
       </tr>
     ))}
   </tbody>

--- a/src/docs/BorderWidth.stories.mdx
+++ b/src/docs/BorderWidth.stories.mdx
@@ -1,6 +1,5 @@
 import { Meta } from '@storybook/addon-docs/blocks';
-import sizes from '@palmetto/palmetto-design-tokens/build/js/variables-size';
-import { BORDER_SIZE_OPTIONS, BORDER_SIZE_VALUES } from '../lib/tokens';
+import { size } from '@palmetto/palmetto-design-tokens/build/js/variables-size';
 
 <Meta title="Design Tokens/Border Width" />
 
@@ -14,20 +13,18 @@ Use these tokens for `border-width`.
       <th>token name</th>
       <th>prop value</th>
       <th>value</th>
-      <th>notes</th>
     </tr>
   </thead>
   <tbody>
-    {BORDER_SIZE_OPTIONS.map((radius, i) => (
+    {Object.entries(size['border']).map(([name, entry], i) => (
       <tr key={i}>
         <td>
-          <code>{`size-border-${radius}`}</code>
+          <code>{`size-border-${name}`}</code>
         </td>
         <td>
-          <code>{radius}</code>
+          <code>{name}</code>
         </td>
-        <td>{BORDER_SIZE_VALUES[i].value}</td>
-        <td>{BORDER_SIZE_VALUES[i].original.comment}</td>
+        <td>{entry.value}</td>
       </tr>
     ))}
   </tbody>

--- a/src/docs/BoxShadow.stories.mdx
+++ b/src/docs/BoxShadow.stories.mdx
@@ -1,6 +1,5 @@
 import { Meta } from '@storybook/addon-docs/blocks';
-import sizes from '@palmetto/palmetto-design-tokens/build/js/variables-size';
-import { BOX_SHADOW_OPTIONS, BOX_SHADOW_VALUES } from '../lib/tokens';
+import { size } from '@palmetto/palmetto-design-tokens/build/js/variables-size';
 
 <Meta title="Design Tokens/Box-Shadow" />
 
@@ -13,17 +12,15 @@ Used these tokens to set the outer shadow of an element.
     <tr>
       <th>token name</th>
       <th>value</th>
-      <th>notes</th>
     </tr>
   </thead>
   <tbody>
-    {BOX_SHADOW_OPTIONS.map((value, i) => (
+    {Object.entries(size['box-shadow']).map(([name, entry], i) => (
       <tr key={i}>
         <td>
-          <code>{`size-box-shadow-${value}`}</code>
+          <code>{`size-box-shadow-${name}`}</code>
         </td>
-        <td>{BOX_SHADOW_VALUES[i].value}</td>
-        <td>{BOX_SHADOW_VALUES[i].original.comment}</td>
+        <td>{entry.value}</td>
       </tr>
     ))}
   </tbody>

--- a/src/docs/Breakpoints.stories.mdx
+++ b/src/docs/Breakpoints.stories.mdx
@@ -1,6 +1,5 @@
 import { Meta } from '@storybook/addon-docs/blocks';
-import sizes from '@palmetto/palmetto-design-tokens/build/js/variables-size';
-import { BREAKPOINT_OPTIONS, BREAKPOINT_VALUES } from '../lib/tokens';
+import { size } from '@palmetto/palmetto-design-tokens/build/js/variables-size';
 
 <Meta
   title="Design Tokens/Breakpoints"
@@ -17,16 +16,18 @@ The following breakpoints are used in utility classes, but you can use them to m
     <tr>
       <th>token name</th>
       <th>value</th>
-      <th>notes</th>
     </tr>
   </thead>
   <tbody>
-    {BREAKPOINT_OPTIONS.map((radius, i) => (
+    {Object.entries(size.breakpoint).map(([name, entry], i) => (
       <tr key={i}>
-        <td><code>{`size-breakpoint-${radius}`}</code></td>
-        <td>{BREAKPOINT_VALUES[i].value}</td>
-        <td>{BREAKPOINT_VALUES[i].original.comment}</td>
+        <td><code>{`size-breakpoint-${name}`}</code></td>
+        <td>{entry.value}</td>
       </tr>
     ))}
+    <tr>
+      <td><code>size-breakpoint-base</code></td>
+      <td>0px</td>
+    </tr>
   </tbody>
 </table>

--- a/src/docs/FontSize.stories.mdx
+++ b/src/docs/FontSize.stories.mdx
@@ -1,6 +1,5 @@
 import { Meta } from '@storybook/addon-docs/blocks';
-import sizes from '@palmetto/palmetto-design-tokens/build/js/variables-size';
-import { FONT_SIZE_OPTIONS, FONT_SIZE_VALUES } from '../lib/tokens';
+import { size } from '@palmetto/palmetto-design-tokens/build/js/variables-size';
 
 <Meta
   title="Design Tokens/Font Size"
@@ -17,17 +16,15 @@ Use these tokens for `font-size`. They are defined in `rem`, which means they wi
       <th>prop value</th>
       <th>value</th>
       <th>px</th>
-      <th>notes</th>
     </tr>
   </thead>
   <tbody>
-    {FONT_SIZE_OPTIONS.map((size, i) => (
+    {Object.entries(size.font).map(([name, entry], i) => (
       <tr key={i}>
-        <td><code>{`size-font-${size}`}</code></td>
-        <td><code>{size}</code></td>
-        <td>{FONT_SIZE_VALUES[i].value}</td>
-        <td>{size === 'base' ? '16' : FONT_SIZE_VALUES[i].original.value * 16}</td>
-        <td>{FONT_SIZE_VALUES[i].original.comment}</td>
+        <td><code>{`size-font-${name}`}</code></td>
+        <td><code>{name}</code></td>
+        <td>{entry.value}</td>
+        <td>{name === 'base' ? '16' : (name === 'inherit' ? '' : entry.original.value * 16)}</td>
       </tr>
     ))}
   </tbody>

--- a/src/docs/FontWeight.stories.mdx
+++ b/src/docs/FontWeight.stories.mdx
@@ -1,6 +1,5 @@
 import { Meta } from '@storybook/addon-docs/blocks';
-import sizes from '@palmetto/palmetto-design-tokens/build/js/variables-size';
-import { FONT_WEIGHT_OPTIONS, FONT_WEIGHT_VALUES } from '../lib/tokens';
+import { size } from '@palmetto/palmetto-design-tokens/build/js/variables-size';
 
 <Meta title="Design Tokens/Font Weight" />
 
@@ -13,17 +12,15 @@ Use these tokens for `font-weight`.
     <tr>
       <th>token name</th>
       <th>value</th>
-      <th>notes</th>
     </tr>
   </thead>
   <tbody>
-    {FONT_WEIGHT_OPTIONS.map((value, i) => (
+    {Object.entries(size['font-weight']).map(([name, entry], i) => (
       <tr key={i}>
         <td>
-          <code>{`size-font-weight-${value}`}</code>
+          <code>{`size-font-weight-${name}`}</code>
         </td>
-        <td>{FONT_WEIGHT_VALUES[i].value}</td>
-        <td>{FONT_WEIGHT_VALUES[i].original.comment}</td>
+        <td>{entry.value}</td>
       </tr>
     ))}
   </tbody>

--- a/src/docs/Height.stories.mdx
+++ b/src/docs/Height.stories.mdx
@@ -1,6 +1,5 @@
 import { Meta } from '@storybook/addon-docs/blocks';
-import sizes from '@palmetto/palmetto-design-tokens/build/js/variables-size';
-import { HEIGHT_OPTIONS, HEIGHT_VALUES } from '../lib/tokens';
+import { size } from '@palmetto/palmetto-design-tokens/build/js/variables-size';
 
 <Meta
   title="Design Tokens/Height"
@@ -19,17 +18,15 @@ Rem based values will scale when adjusting the root font size. Pixel values are 
       <th>prop value</th>
       <th>value</th>
       <th>px</th>
-      <th>notes</th>
     </tr>
   </thead>
   <tbody>
-    {HEIGHT_OPTIONS.map((height, i) => (
+    {Object.entries(size.height).map(([name, entry], i) => (
       <tr key={i}>
-        <td><code>{`size-height-${height}`}</code></td>
-        <td><code>{height}</code></td>
-        <td>{HEIGHT_VALUES[i].value}</td>
-        <td>{height === 'base' ? '16' : HEIGHT_VALUES[i].value.includes('%') ? '' : HEIGHT_VALUES[i].original.value * 16}</td>
-        <td>{HEIGHT_VALUES[i].original.comment}</td>
+        <td><code>{`size-height-${name}`}</code></td>
+        <td><code>{name}</code></td>
+        <td>{entry.value}</td>
+        <td>{name === 'base' ? '16' : (entry.value.includes('%') || ['inherit', 'auto'].includes(name)) ? '' : entry.original.value * 16}</td>
       </tr>
     ))}
   </tbody>

--- a/src/docs/LineHeight.stories.mdx
+++ b/src/docs/LineHeight.stories.mdx
@@ -1,6 +1,5 @@
 import { Meta } from '@storybook/addon-docs/blocks';
-import sizes from '@palmetto/palmetto-design-tokens/build/js/variables-size';
-import { LINE_HEIGHT_OPTIONS, LINE_HEIGHT_VALUES } from '../lib/tokens';
+import { size } from '@palmetto/palmetto-design-tokens/build/js/variables-size';
 
 <Meta title="Design Tokens/Line-Height" />
 
@@ -14,17 +13,15 @@ Usually, the line-height is already set by the parent.
     <tr>
       <th>token name</th>
       <th>value</th>
-      <th>notes</th>
     </tr>
   </thead>
   <tbody>
-    {LINE_HEIGHT_OPTIONS.map((value, i) => (
+    {Object.entries(size['line-height']).map(([name, entry], i) => (
       <tr key={i}>
         <td>
-          <code>{`size-line-height-${value}`}</code>
+          <code>{`size-line-height-${name}`}</code>
         </td>
-        <td>{LINE_HEIGHT_VALUES[i].value}</td>
-        <td>{LINE_HEIGHT_VALUES[i].original.comment}</td>
+        <td>{entry.value}</td>
       </tr>
     ))}
   </tbody>

--- a/src/docs/Spacing.stories.mdx
+++ b/src/docs/Spacing.stories.mdx
@@ -1,6 +1,5 @@
 import { Meta } from '@storybook/addon-docs/blocks';
-import sizes from '@palmetto/palmetto-design-tokens/build/js/variables-size';
-import { SPACING_OPTIONS, SPACING_VALUES } from '../lib/tokens';
+import { size } from '@palmetto/palmetto-design-tokens/build/js/variables-size';
 
 <Meta
   title="Design Tokens/Spacing"
@@ -17,17 +16,15 @@ Spacing tokens are intended for use with `margin` and `padding` properties. They
       <th>prop value</th>
       <th>value</th>
       <th>px</th>
-      <th>notes</th>
     </tr>
   </thead>
   <tbody>
-    {SPACING_OPTIONS.map((space, i) => (
+    {Object.entries(size.spacing).map(([name, entry], i) => (
       <tr key={i}>
-        <td><code>{`size-spacing-${space}`}</code></td>
-        <td><code>{space}</code></td>
-        <td>{SPACING_VALUES[i].value}</td>
-        <td>{space === 'base' ? '16' : SPACING_VALUES[i].original.value * 16}</td>
-        <td>{SPACING_VALUES[i].original.comment}</td>
+        <td><code>{`size-spacing-${name}`}</code></td>
+        <td><code>{name}</code></td>
+        <td>{entry.value}</td>
+        <td>{name === 'base' ? '16' : (['inherit', 'auto'].includes(name) ? '' : entry.original.value * 16)}</td>
       </tr>
     ))}
   </tbody>

--- a/src/docs/Width.stories.mdx
+++ b/src/docs/Width.stories.mdx
@@ -1,6 +1,5 @@
 import { Meta } from '@storybook/addon-docs/blocks';
-import sizes from '@palmetto/palmetto-design-tokens/build/js/variables-size';
-import { WIDTH_OPTIONS, WIDTH_VALUES } from '../lib/tokens';
+import { size } from '@palmetto/palmetto-design-tokens/build/js/variables-size';
 
 <Meta
   title="Design Tokens/Width"
@@ -19,17 +18,15 @@ Rem based values will scale when adjusting the root font size. Pixel values are 
       <th>prop value</th>
       <th>value</th>
       <th>px</th>
-      <th>notes</th>
     </tr>
   </thead>
   <tbody>
-    {WIDTH_OPTIONS.map((width, i) => (
+    {Object.entries(size.width).map(([name, entry], i) => (
       <tr key={i}>
-        <td><code>{`size-width-${width}`}</code></td>
-        <td><code>{width}</code></td>
-        <td>{WIDTH_VALUES[i].value}</td>
-        <td>{width === 'base' ? '16' : WIDTH_VALUES[i].value.includes('%') ? '' : WIDTH_VALUES[i].original.value * 16}</td>
-        <td>{WIDTH_VALUES[i].original.comment}</td>
+        <td><code>{`size-width-${name}`}</code></td>
+        <td><code>{name}</code></td>
+        <td>{entry.value}</td>
+        <td>{name === 'base' ? '16' : (entry.value.includes('%') || ['auto', 'inherit'].includes(name)) ? '' : entry.original.value * 16}</td>
       </tr>
     ))}
   </tbody>

--- a/src/docs/ZIndex.stories.mdx
+++ b/src/docs/ZIndex.stories.mdx
@@ -1,6 +1,5 @@
 import { Meta } from '@storybook/addon-docs/blocks';
-import sizes from '@palmetto/palmetto-design-tokens/build/js/variables-size';
-import { Z_INDEX_OPTIONS, Z_INDEX_VALUES } from '../lib/tokens';
+import { size } from '@palmetto/palmetto-design-tokens/build/js/variables-size';
 
 <Meta title="Design Tokens/Z-Index" />
 
@@ -13,17 +12,15 @@ Used these tokens to set the z-index order of layering elements.
     <tr>
       <th>token name</th>
       <th>value</th>
-      <th>notes</th>
     </tr>
   </thead>
   <tbody>
-    {Z_INDEX_OPTIONS.map((value, i) => (
+    {Object.entries(size['z-index']).map(([name, entry], i) => (
       <tr key={i}>
         <td>
-          <code>{`size-z-index-${value}`}</code>
+          <code>{`size-z-index-${name}`}</code>
         </td>
-        <td>{Z_INDEX_VALUES[value].value}</td>
-        <td>{Z_INDEX_VALUES[value].original.comment}</td>
+        <td>{entry.value}</td>
       </tr>
     ))}
   </tbody>

--- a/src/docs/colors/Colors.module.scss
+++ b/src/docs/colors/Colors.module.scss
@@ -4,7 +4,6 @@
   border-radius: var(--size-border-radius-md);
   padding: var(--size-spacing-md);
   width: 130px;
-  color: var(--color-brand-white-base);
 }
 
 .palette-item {

--- a/src/docs/colors/Colors.stories.jsx
+++ b/src/docs/colors/Colors.stories.jsx
@@ -1,7 +1,7 @@
 /* eslint-disable no-unused-vars */
 import React from 'react';
 import { withA11y } from '@storybook/addon-a11y';
-import { BRAND_COLORS } from '../../lib/tokens';
+import { color } from '@palmetto/palmetto-design-tokens/build/json/variables-color.json';
 import styles from './Colors.module.scss';
 
 export default {
@@ -11,9 +11,13 @@ export default {
 
 const renderColorBlock = colorEntry => {
   const [colorName, colorVariations] = colorEntry;
+  console.log('colorName', colorName);
 
   return (
-    <div className={styles['color-block']} style={{ backgroundColor: `${colorVariations.base.value}` }}>
+    <div
+      className={`${styles['color-block']} ${['white', 'light'].includes(colorName) ? 'font-color-dark' : 'font-color-white'}`}
+      style={{ backgroundColor: `${colorVariations.base.value}` }}
+    >
       <h2>{colorName}</h2>
       <p>{colorVariations.base.value}</p>
     </div>
@@ -23,9 +27,23 @@ const renderColorBlock = colorEntry => {
 const renderColorPalette = (colorEntry, index) => {
   const [colorName, colorVariations] = colorEntry;
 
-  const getFontColor = colorVariation => (
-    colorVariation && colorVariation.attributes && colorVariation.attributes.font === 'base' ? 'black' : 'white'
-  );
+  const getFontColor = (colorVariation) => {
+    const variationsWithDarkFont = [
+      'white',
+      'light',
+      'lighter',
+      'lightest',
+      '50',
+      '100',
+      '200',
+    ];
+
+    if (variationsWithDarkFont.includes(colorVariation)) {
+      return 'dark';
+    }
+
+    return 'white';
+  };
 
   return (
     <div key={index}>
@@ -39,7 +57,7 @@ const renderColorPalette = (colorEntry, index) => {
             className={styles['palette-item']}
             style={{
               backgroundColor: `${colorVariation.value}`,
-              color: `${getFontColor(colorVariation)}`,
+              color: `${getFontColor(colorVariationName)}`,
             }}
           >
             <small style={{ display: 'block' }}>{colorVariationName}</small>
@@ -60,7 +78,7 @@ export const brand = () => (
         flexWrap: 'wrap',
       }}
     >
-      {Object.entries(BRAND_COLORS).map(renderColorBlock)}
+      {Object.entries(color.brand).map(renderColorBlock)}
     </div>
     <h1>Extended Brand Palette</h1>
     <div
@@ -69,7 +87,7 @@ export const brand = () => (
         flexWrap: 'wrap',
       }}
     >
-      {Object.entries(BRAND_COLORS).map(renderColorPalette)}
+      {Object.entries(color.brand).map(renderColorPalette)}
     </div>
   </>
 );

--- a/src/lib/tokens.ts
+++ b/src/lib/tokens.ts
@@ -16,7 +16,6 @@ import {
   HeightSize,
   LineHeightSize,
   SpacingSize,
-  UnknownPropertiesObjType,
   WidthSize,
   ZIndexSize,
   IconName,
@@ -35,7 +34,7 @@ export const BREAKPOINT_VALUES = Object.values(size.breakpoint);
 export const BREAKPOINTS = [...Object.entries(size.breakpoint), ['base', 0]]
   .map(([name, value]) => ({
     name,
-    minWidth: parseInt(value as string),
+    minWidth: parseInt(value as string, 10),
   })) as Breakpoint[];
 
 export const BRAND_COLOR_OPTIONS = (Object.keys(color.brand) as ColorName[])
@@ -46,7 +45,8 @@ export const BRAND_COLOR_OPTIONS = (Object.keys(color.brand) as ColorName[])
 
 export const BRAND_COLOR_NAMES = Object.keys(color.brand) as ColorName[];
 export const BRAND_COLOR_VALUES = Object.values(color.brand);
-export const BASE_BRAND_COLORS = Object.entries({ ...color.brand }).reduce((acc, [key, value]) => ( { ...acc, [key]: (value?.base ) }), {}) as { [color in ColorName]: string };
+export const BASE_BRAND_COLORS = Object.entries({ ...color.brand })
+  .reduce((acc, [key, value]) => ({ ...acc, [key]: value?.base }), {}) as { [c in ColorName]: string };
 
 export const FONT_COLOR_OPTIONS = [...BRAND_COLOR_OPTIONS] as FontColor[];
 export const FONT_COLOR_VALUES = color.brand;

--- a/src/lib/tokens.ts
+++ b/src/lib/tokens.ts
@@ -1,5 +1,5 @@
-import { size } from '@palmetto/palmetto-design-tokens/build/json/variables-size.json';
-import { color } from '@palmetto/palmetto-design-tokens/build/json/variables-color.json';
+import { size } from '@palmetto/palmetto-design-tokens/build/json/values/variables-size.json';
+import { color } from '@palmetto/palmetto-design-tokens/build/json/values/variables-color.json';
 import { ICON_NAMES as iconNames } from '@palmetto/palmetto-design-tokens/build/icons';
 
 import {
@@ -32,10 +32,10 @@ export const BORDER_SIZE_VALUES = Object.values(size.border);
 export const BREAKPOINT_OPTIONS = Object.keys(size.breakpoint) as BreakpointSizeWithBase[];
 export const BREAKPOINT_VALUES = Object.values(size.breakpoint);
 
-export const BREAKPOINTS = [...Object.entries(size.breakpoint), ['base', { original: { value: 0 } }]]
-  .map((entry: UnknownPropertiesObjType) => ({
-    name: entry[0],
-    minWidth: parseInt(entry[1].original.value, 10),
+export const BREAKPOINTS = [...Object.entries(size.breakpoint), ['base', 0]]
+  .map(([name, value]) => ({
+    name,
+    minWidth: parseInt(value as string),
   })) as Breakpoint[];
 
 export const BRAND_COLOR_OPTIONS = (Object.keys(color.brand) as ColorName[])
@@ -44,34 +44,33 @@ export const BRAND_COLOR_OPTIONS = (Object.keys(color.brand) as ColorName[])
       .map(colorGrade => (colorGrade === 'base' ? colorName : `${colorName}-${colorGrade}`))
   )).flat() as BrandColor[];
 
-// export const BRAND_COLOR_OPTIONS = [...BRAND_COLORS] as BrandColor[];
 export const BRAND_COLOR_NAMES = Object.keys(color.brand) as ColorName[];
 export const BRAND_COLOR_VALUES = Object.values(color.brand);
-export const BRAND_COLORS = color.brand;
+export const BASE_BRAND_COLORS = Object.entries({ ...color.brand }).reduce((acc, [key, value]) => ( { ...acc, [key]: (value?.base ) }), {}) as { [color in ColorName]: string };
 
 export const FONT_COLOR_OPTIONS = [...BRAND_COLOR_OPTIONS] as FontColor[];
-export const FONT_COLOR_VALUES = Object.values(color.font);
+export const FONT_COLOR_VALUES = color.brand;
 
 export const FONT_SIZE_OPTIONS = Object.keys(size.font) as FontSize[];
-export const FONT_SIZE_VALUES = Object.values(size.font);
+export const FONT_SIZE_VALUES = size.font;
 
 export const FONT_WEIGHT_OPTIONS = Object.keys(size['font-weight']) as FontWeight[];
-export const FONT_WEIGHT_VALUES = Object.values(size['font-weight']);
+export const FONT_WEIGHT_VALUES = size['font-weight'];
 
 export const LINE_HEIGHT_OPTIONS = Object.keys(size['line-height']) as LineHeightSize[];
-export const LINE_HEIGHT_VALUES = Object.values(size['line-height']);
+export const LINE_HEIGHT_VALUES = size['line-height'];
 
 export const SPACING_OPTIONS = Object.keys(size.spacing) as SpacingSize[];
-export const SPACING_VALUES = Object.values(size.spacing);
+export const SPACING_VALUES = size.spacing;
 
 export const WIDTH_OPTIONS = Object.keys(size.width) as WidthSize[];
-export const WIDTH_VALUES = Object.values(size.width);
+export const WIDTH_VALUES = size.width;
 
 export const HEIGHT_OPTIONS = Object.keys(size.height) as HeightSize[];
-export const HEIGHT_VALUES = Object.values(size.height);
+export const HEIGHT_VALUES = size.height;
 
 export const Z_INDEX_OPTIONS = Object.keys(size['z-index']) as ZIndexSize[];
 export const Z_INDEX_VALUES = size['z-index'];
 
 export const BOX_SHADOW_OPTIONS = Object.keys(size['box-shadow']) as BoxShadowSize[];
-export const BOX_SHADOW_VALUES = Object.values(size['box-shadow']);
+export const BOX_SHADOW_VALUES = size['box-shadow'];

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -114,6 +114,7 @@ module.exports = {
     reset: [path.join(__dirname, 'src/styles/reset.scss')], // CSS Reset only.
   },
   optimization: {
+    usedExports: true,
     minimizer: [
       // Minify Javascript
       new TerserJSPlugin({

--- a/yarn.lock
+++ b/yarn.lock
@@ -1957,10 +1957,10 @@
   dependencies:
     "@types/node" ">= 8"
 
-"@palmetto/palmetto-design-tokens@0.37.0":
-  version "0.37.0"
-  resolved "https://registry.yarnpkg.com/@palmetto/palmetto-design-tokens/-/palmetto-design-tokens-0.37.0.tgz#5a1a7ca77e51b80da18af2a8b86f81bfcb80c784"
-  integrity sha512-+QbbX6A/tYeMN1Sn1ZECjUnU5ET9Y3e6h8y9U6/JmpL517Y49rR1vq+Fat54pc2fvgU0vbmLl/JxdijCvOunPw==
+"@palmetto/palmetto-design-tokens@0.38.1":
+  version "0.38.1"
+  resolved "https://registry.yarnpkg.com/@palmetto/palmetto-design-tokens/-/palmetto-design-tokens-0.38.1.tgz#becf54d5b73e44f477795ad82e3c97a2307fe340"
+  integrity sha512-6L39fWbx/TSjMuCElN0XeXoH/MDleIex/Jgbhi8RttWjfLegq6qBLP6XFqud5sSBERnjXLUKjyn68Ujsxm5QWg==
 
 "@pmmmwh/react-refresh-webpack-plugin@^0.4.2":
   version "0.4.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1957,10 +1957,10 @@
   dependencies:
     "@types/node" ">= 8"
 
-"@palmetto/palmetto-design-tokens@0.38.1":
-  version "0.38.1"
-  resolved "https://registry.yarnpkg.com/@palmetto/palmetto-design-tokens/-/palmetto-design-tokens-0.38.1.tgz#becf54d5b73e44f477795ad82e3c97a2307fe340"
-  integrity sha512-6L39fWbx/TSjMuCElN0XeXoH/MDleIex/Jgbhi8RttWjfLegq6qBLP6XFqud5sSBERnjXLUKjyn68Ujsxm5QWg==
+"@palmetto/palmetto-design-tokens@0.38.2":
+  version "0.38.2"
+  resolved "https://registry.yarnpkg.com/@palmetto/palmetto-design-tokens/-/palmetto-design-tokens-0.38.2.tgz#39f8269f27520c736c76734cfa27ab4dfbcf365e"
+  integrity sha512-oaAjSqRKEKsyp9PuYRXyZEVYkMsGJo+p3HAYvKHFJB6FgdTK7ibkhKmUTBWQINN0g3Los3jqybikvb0MxEhN2A==
 
 "@pmmmwh/react-refresh-webpack-plugin@^0.4.2":
   version "0.4.3"


### PR DESCRIPTION
# Github Issue or Trello Card
This PR addresses this issue: https://trello.com/c/wQom9fAu/628-refactor-palmett-components-to-use-smaller-dictionary-formats

# What type of change is this?
Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Updating documentation.
- [ ] Updating deployment/build pipeline.

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes

# UI Checklist
- [X] I have conducted visual UAT on my changes/features.
- [X] My solution works well on desktop, tablet, and mobile browsers.