### PR TITLE
feat: allow popover to be server-side rendered

### DIFF
--- a/src/components/DateInput/DateInput.tsx
+++ b/src/components/DateInput/DateInput.tsx
@@ -131,6 +131,7 @@ export const DateInput: FC<DateInputProps> = ({
       isOpen={isPopoverOpen}
       content={renderDatePicker()}
       withPortal
+      portalTarget={document.body}
       onClickOutside={() => handleTogglePopover(false)}
     >
       <TextInput

--- a/src/components/Popover/Popover.Overview.stories.mdx
+++ b/src/components/Popover/Popover.Overview.stories.mdx
@@ -136,6 +136,7 @@ of uses for a popover include:
               direction: 'column',
             }}
             withPortal
+            portalTarget={document.body}
           >
             <Button onClick={handleOpenPopover} variant="light" size="sm">
               Popover Menu &nbsp;
@@ -397,6 +398,7 @@ in order to render the element anywhere on the page.
               color: 'white',
             }}
             withPortal
+            portalTarget={document.body}
           >
             <Button onClick={handleOpenPopover} variant="light">
               Toggle Popover
@@ -440,6 +442,7 @@ NOTE: this should be use sparingly since context dependent on hover, isn't an op
               background: 'primary-light',
             }}
             withPortal
+            portalTarget={document.body}
           >
             <Button
               onMouseOver={() => setPopoverOpen(true)}
@@ -492,6 +495,7 @@ in cases where the click target includes the Popover trigger or content nodes.
               background: 'primary-light',
             }}
             withPortal
+            portalTarget={document.body}
             onClickOutside={() => setPopoverOpen(false)}
           >
             <Button onClick={handleTogglePopover} variant="light">
@@ -543,6 +547,7 @@ Use the `trapFocus` prop to constrain focus to popover content elements.
               background: 'grey-lightest',
             }}
             withPortal
+            portalTarget={document.body}
             onClickOutside={() => setPopoverOpen(false)}
             trapFocus
           >
@@ -590,6 +595,7 @@ Render the popover with no arrow by passing `hasArrow` false.
               background: 'grey-lightest',
             }}
             withPortal
+            portalTarget={document.body}
             onClickOutside={() => setPopoverOpen(false)}
             hasArrow={false}
           >
@@ -638,6 +644,7 @@ Place the popover closer or farther from its trigger with the `offsetFromTarget`
                 background: 'grey-lightest',
               }}
               withPortal
+              portalTarget={document.body}
               hasArrow={false}
               offsetFromTarget={offset}
             >

--- a/src/components/Popover/Popover.VisualTests.stories.tsx
+++ b/src/components/Popover/Popover.VisualTests.stories.tsx
@@ -1,9 +1,11 @@
-import React, { useState } from 'react';
+import React, { FC, useState } from 'react';
+import { Meta, Story } from '@storybook/react/types-6-0';
+import { Placement as PlacementType } from '@popperjs/core';
 import { Popover } from './Popover';
 import { Button } from '../Button/Button';
 import { Box } from '../Box/Box';
 import { Heading } from '../Heading/Heading';
-import { Icon } from '../Icon/Icon';
+import { Icon, IconProps } from '../Icon/Icon';
 
 export default {
   title: 'Components/Popover/Visual Regression Tests',
@@ -11,14 +13,14 @@ export default {
   parameters: {
     chromatic: { delay: 2000, pauseAnimationAtEnd: true },
   },
-};
+} as Meta;
 
-export const Demo = () => {
+export const Demo: Story = () => {
   const [isPopoverOpen, setPopoverOpen] = useState(true);
   const handleOpenPopover = () => {
     setPopoverOpen(!isPopoverOpen);
   };
-  const NavItem = ({ children, className, iconName }) => (
+  const NavItem: FC<{className?: string; iconName?: IconProps['name'];}> = ({ children, className, iconName }) => (
     <Box
       as="li"
       color="grey-500"
@@ -118,6 +120,7 @@ export const Demo = () => {
           direction: 'column',
         }}
         withPortal
+        portalTarget={document.body}
       >
         <Button onClick={handleOpenPopover} variant="light" size="sm">
           Popover Menu &nbsp;
@@ -128,7 +131,7 @@ export const Demo = () => {
   );
 };
 
-export const Default = () => {
+export const Default: Story = () => {
   const [isPopoverOpen, setPopoverOpen] = useState(true);
   const handleOpenPopover = () => {
     setPopoverOpen(!isPopoverOpen);
@@ -152,8 +155,8 @@ export const Default = () => {
   );
 };
 
-export const Placement = () => {
-  const [isPopoverOpen, setPopoverOpen] = useState({
+export const Placement: Story = () => {
+  const [isPopoverOpen, setPopoverOpen] = useState<Record<string, boolean>>({
     auto: true,
     'auto-start': true,
     'auto-end': true,
@@ -170,10 +173,10 @@ export const Placement = () => {
     'left-start': true,
     'left-end': true,
   });
-  const handleOpenPopover = key => {
+  const handleOpenPopover = (key: string) => {
     setPopoverOpen({ ...isPopoverOpen, [key]: !isPopoverOpen[key] });
   };
-  const positions = [
+  const positions: PlacementType[] = [
     'auto',
     'auto-start',
     'auto-end',
@@ -214,7 +217,7 @@ export const Placement = () => {
   );
 };
 
-export const HideArrow = () => {
+export const HideArrow: Story = () => {
   const [isPopoverOpen, setPopoverOpen] = useState(true);
   const handleTogglePopover = () => {
     setPopoverOpen(!isPopoverOpen);
@@ -238,6 +241,7 @@ export const HideArrow = () => {
           background: 'grey-lightest',
         }}
         withPortal
+        portalTarget={document.body}
         onClickOutside={() => setPopoverOpen(false)}
         hasArrow={false}
       >
@@ -249,7 +253,7 @@ export const HideArrow = () => {
   );
 };
 
-export const Offset = () => {
+export const Offset: Story = () => {
   const [isPopoverOpen, setPopoverOpen] = useState(true);
   const handleTogglePopoverNear = () => {
     setPopoverOpen(!isPopoverOpen);
@@ -274,6 +278,7 @@ export const Offset = () => {
             background: 'grey-lightest',
           }}
           withPortal
+          portalTarget={document.body}
           hasArrow={false}
           offsetFromTarget={20}
         >

--- a/src/components/Popover/Popover.test.tsx
+++ b/src/components/Popover/Popover.test.tsx
@@ -113,6 +113,7 @@ describe('Popover', () => {
                 isOpen
                 content={<button type="button" id="inside-button">hello</button>}
                 withPortal
+                portalTarget={document.body}
               >
                 <p>trigger</p>
               </Popover>

--- a/src/components/Popover/Popover.tsx
+++ b/src/components/Popover/Popover.tsx
@@ -18,7 +18,7 @@ import { BrandColor } from '../../types';
 import styles from './Popover.module.scss';
 import { Box, BoxProps } from '../Box/Box';
 
-export interface PopoverProps {
+export type PopoverProps = {
   /**
    * The trigger element
    */
@@ -62,15 +62,16 @@ export interface PopoverProps {
    */
   placement?: Placement;
   /**
-   * The target element where the Popover will be portaled to, when `withPortal === true`.
-   */
-  portalTarget?: HTMLElement;
-  /**
    * Whether you want to trap focus in the Popover element when it is open.
    * Read more about focus traps:
    * [Here](https://allyjs.io/tutorials/accessible-dialog.html#trapping-focus-inside-the-dialog)
    */
   trapFocus?: boolean;
+  /**
+   * Additional props to be spread to rendered element
+   */
+  [x: string]: any; // eslint-disable-line
+} & ({
   /**
    * Whether the element should be rendered outside its DOM structure
    * for reasons of placement. Use this when the element is being cut-off or
@@ -78,12 +79,15 @@ export interface PopoverProps {
    * NOTE: use `portalTarget` to render the element onto a custom container,
    * otherwise it will be rendered to the `body` element by default.
    */
-  withPortal?: boolean;
-  /**
-   * Additional props to be spread to rendered element
+  withPortal: true;
+   /**
+   * The target element where the Popover will be portaled to, when `withPortal === true`.
    */
-  [x: string]: any; // eslint-disable-line
-}
+  portalTarget?: HTMLElement;
+} | {
+  withPortal?: false;
+  portalTarget?: never;
+})
 
 const contentContainerDefaults: BoxProps = {
   background: 'white',
@@ -101,9 +105,9 @@ export const Popover: FC<PopoverProps> = ({
   offsetFromTarget = 12,
   onClickOutside = undefined,
   placement = 'right',
-  portalTarget = document.body,
-  trapFocus = false,
   withPortal = false,
+  portalTarget = withPortal ? document.body : undefined,
+  trapFocus = false,
   ...restProps
 }) => {
   const triggerRef = useRef<HTMLElement>(null);
@@ -246,7 +250,7 @@ export const Popover: FC<PopoverProps> = ({
     <>
       {childrenWithRef}
       {isOpen && (
-        withPortal ? createPortal(renderPopperContent(), portalTarget) : renderPopperContent()
+        withPortal && portalTarget ? createPortal(renderPopperContent(), portalTarget) : renderPopperContent()
       )}
     </>
   );

--- a/src/components/Popover/Popover.tsx
+++ b/src/components/Popover/Popover.tsx
@@ -76,14 +76,15 @@ export type PopoverProps = {
    * Whether the element should be rendered outside its DOM structure
    * for reasons of placement. Use this when the element is being cut-off or
    * re-positioned due to lack of space in the parent container.
-   * NOTE: use `portalTarget` to render the element onto a custom container,
-   * otherwise it will be rendered to the `body` element by default.
+   * NOTE: `portalTarget` is required if this is true.
    */
   withPortal: true;
    /**
    * The target element where the Popover will be portaled to, when `withPortal === true`.
+   * `document.body` will work for many cases, but you can also use a custom container for this.
+   * Only required if withPortal is true.
    */
-  portalTarget?: HTMLElement;
+  portalTarget: HTMLElement;
 } | {
   withPortal?: false;
   portalTarget?: never;
@@ -106,7 +107,7 @@ export const Popover: FC<PopoverProps> = ({
   onClickOutside = undefined,
   placement = 'right',
   withPortal = false,
-  portalTarget = withPortal ? document.body : undefined,
+  portalTarget,
   trapFocus = false,
   ...restProps
 }) => {
@@ -250,6 +251,7 @@ export const Popover: FC<PopoverProps> = ({
     <>
       {childrenWithRef}
       {isOpen && (
+        // portalTarget should always be defined if withPortal is true, but better safe than sorry here!
         withPortal && portalTarget ? createPortal(renderPopperContent(), portalTarget) : renderPopperContent()
       )}
     </>


### PR DESCRIPTION
# Github Issue or Trello Card
This PR addresses this issue: https://trello.com/c/bC292LqA

Palmetto.com has to force some clients to only render on the client-side instead of being server-side rendered. This fixes that for any components using Popover directly, but not through DateInput (DateInput forces withPortal to true, which renders it with a portalTarget of document.body).

LMK what you think of the typing, esp around the discriminated union. It prohibits setting portalTarget unless withPortal is true. I did this because we only ever need portalTarget if withPortal is true. I wanted to make it only required if withPortal is true but couldn't do that with the param initialization!

# What type of change is this?
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [x] My code follows the style guidelines of this project
          The typing for Popover isn't quite the same. Let me know if that's a problem.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

# UI Checklist
- [x] I have conducted visual UAT on my changes/features.
        the storybook still looked good/worked! P.com proposal also still looks good.
- [x] My solution works well on desktop, tablet, and mobile browsers.