### PR TITLE
fix(animation): fix fade in animation

### DIFF
--- a/src/styles/animation.scss
+++ b/src/styles/animation.scss
@@ -15,7 +15,7 @@
   }
 
   100% {
-    opacity: 100%;
+    opacity: 1;
     transform: translateY(0);
   }
 }


### PR DESCRIPTION
opacity values should be from `0` to `1`. For some reason the 100% value works in storybook, but the animation doesn't work (it just appears without fading) when used by another app.

https://developer.mozilla.org/en-US/docs/Web/CSS/opacity



# What type of change is this?
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Updating documentation.
- [ ] Updating deployment/build pipeline.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

# UI Checklist
- [x] I have conducted visual UAT on my changes/features.
- [x] My solution works well on desktop, tablet, and mobile browsers.