### PR TITLE
fix: make fadeInUp animation more subtle for modals

### DIFF
--- a/src/styles/animation.scss
+++ b/src/styles/animation.scss
@@ -11,7 +11,7 @@
 @keyframes fadeInUp {
   0% {
     opacity: 0;
-    transform: translateY(100%);
+    transform: translateY(30%);
   }
 
   100% {


### PR DESCRIPTION
For tall modals (scrolling content) the 100% translateY causes some weird animation behavoir. This PR reduces the amount of Y position movement so that the modal doesn't have to travel as far.

Before (notice the jerkiness of the animation):

https://user-images.githubusercontent.com/1447339/119697329-ef5e1880-be04-11eb-9b79-cc0ae5deaead.mov

After:


https://user-images.githubusercontent.com/1447339/119697356-f4bb6300-be04-11eb-80c9-6159b5ebde62.mov



# What type of change is this?
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Updating documentation.
- [ ] Updating deployment/build pipeline.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

# UI Checklist
- [ ] I have conducted visual UAT on my changes/features.
- [ ] My solution works well on desktop, tablet, and mobile browsers.