### PR TITLE
Updating value type to match available option types

### DIFF
--- a/src/components/SelectInputNative/SelectInputNative.tsx
+++ b/src/components/SelectInputNative/SelectInputNative.tsx
@@ -8,7 +8,7 @@ export interface SelectInputNativeBaseProps extends BoxProps, FormControlProps {
   /**
    * Value of selected option. Should match the value key in the option object.
    */
-  value: string | null;
+  value: string | number | null;
   /**
    * onChange callback from select element.
    */


### PR DESCRIPTION
# Overview

When selecting a utility provider and tariff, we receive the tarriffId as a number. When I pass in that number into the value field of the SelectInputNative, I get a type error that it doesn't match a string:

![image](https://user-images.githubusercontent.com/689451/121241497-c0aa5e00-c858-11eb-8a19-c978751395a8.png)

I believe SelectInputNative should accept a value that matches the types of the option's keys.

# Github Issue or Trello Card
This PR addresses this issue: 
https://trello.com/c/74yuGx9I/1943-utility-rate-selection-limited-to-the-first-entry

# What type of change is this?

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Updating documentation.

Before Doc: 
![image](https://user-images.githubusercontent.com/689451/121241615-de77c300-c858-11eb-9649-1b5cdc318247.png)
After Doc: 
![image](https://user-images.githubusercontent.com/689451/121241646-e6376780-c858-11eb-8d33-6852cf0657d0.png)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

# UI Checklist
- [x] I have conducted visual UAT on my changes/features.
- [x] My solution works well on desktop, tablet, and mobile browsers.