### PR TITLE
Update prop descriptions for Button

### DIFF
--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -27,7 +27,7 @@ export interface ButtonProps {
    */
   className?: string;
   /**
-   * Make button take full width of container.
+   * Button takes up the full width of its parent container.
    */
   fullWidth?: boolean;
   /**
@@ -52,7 +52,7 @@ export interface ButtonProps {
    */
   isDisabled?: boolean;
   /**
-   * Button takes up the full width of its parent container.
+   * Renders a loading spinner on the button.
    */
   isLoading?: boolean;
   /**

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -52,7 +52,7 @@ export interface ButtonProps {
    */
   isDisabled?: boolean;
   /**
-   * Renders a loading spinner on the button.
+   * Replaces the button text with a loading indicator and disables the button.
    */
   isLoading?: boolean;
   /**


### PR DESCRIPTION
This PR just updates a few of the comments in the button component. I assumed these comments are being used to generate the prop description text seen in Storybook, which is where I noticed this issue:

<img width="871" alt="Screen Shot 2021-06-09 at 11 12 02 AM" src="https://user-images.githubusercontent.com/3791646/121412395-848b0200-c919-11eb-976d-a785f041e141.png">

So I came up with a description I thought would fit better for `isLoading`, basically copied from the example text above it in the docs. I also thought that mismatched string was more descriptive than the current `fullWidth` string, so I replaced that as well.

# What type of change is this?
Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Updating documentation.
- [ ] Updating deployment/build pipeline.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

# UI Checklist
- [x] I have conducted visual UAT on my changes/features.
- [ ] My solution works well on desktop, tablet, and mobile browsers.