### PR TITLE
feat(Modal): automatically apply top border radius to Modals

### DIFF
--- a/src/components/Modal/Modal.Overview.stories.mdx
+++ b/src/components/Modal/Modal.Overview.stories.mdx
@@ -68,7 +68,7 @@ Use the `Modal.Body` and `Modal.Footer` to add body and footer content. These co
       return (
         <div>
           <Button variant="light" onClick={open}>
-            Show Modal
+            Show Modal With Body and Footer
           </Button>
           <Modal ariaLabelledBy="titleFooterBody" isOpen={showModal} onDismiss={close}>
             <Modal.Header id="titleFooterBody" title="The Modal Title" onDismiss={close} />
@@ -94,7 +94,7 @@ Set the `onDismiss` prop on the `Modal.Header` to true to automatically add a cl
       return (
         <div>
           <Button variant="light" onClick={open}>
-            Show Modal
+            Show Modal With Close Button
           </Button>
           <Modal ariaLabel="modal with close button" isOpen={showModal} onDismiss={close}>
             <Modal.Header onDismiss={close} />
@@ -119,7 +119,7 @@ Omit `<Modal.Header/>` to render a minimal modal without a header.
       return (
         <div>
           <Button variant="light" onClick={open}>
-            Show Modal
+            Show Modal Without Header
           </Button>
           <Modal ariaLabel="Modal without a header" isOpen={showModal} onDismiss={close}>
             <Modal.Body>Modal content</Modal.Body>
@@ -149,7 +149,7 @@ Use `fullScreenMobile` to enable fullscreen at mobile viewport widths.
       return (
         <div>
           <Button variant="light" onClick={open}>
-            Show Modal
+            Show Fullscreen On Mobile Modal
           </Button>
           <Modal
             ariaLabelledBy="titleFullscreen"

--- a/src/components/Modal/Modal.module.scss
+++ b/src/components/Modal/Modal.module.scss
@@ -62,6 +62,7 @@
   background-color: var(--modal-background-color);
   padding: 0;
   width: 100%;
+  border-radius: var(--modal-border-radius) var(--modal-border-radius) 0 0;
 
   :global {
     animation: slideInUp 0.3s;
@@ -95,6 +96,7 @@
     right: 0;
     bottom: 0;
     left: 0;
+    border-radius: 0;
   }
 
   @media (min-width: $size-breakpoint-tablet) {


### PR DESCRIPTION
# Github Issue or Trello Card

This PR automatically adds a top border radius to a Modal dialog on mobile views. This is to give the modal dialog a more "card" like appearance on mobile devices.

Before
<img width="423" alt="Screen Shot 2021-06-09 at 5 13 09 PM" src="https://user-images.githubusercontent.com/1447339/121445269-faa55e00-c945-11eb-8663-1aa3f0a7e9eb.png">

After
<img width="422" alt="Screen Shot 2021-06-09 at 5 13 48 PM" src="https://user-images.githubusercontent.com/1447339/121445345-1dd00d80-c946-11eb-9bed-409a1838a2e2.png">

However, if `fullScreenMobile ` is true, then there is no radius.
<img width="439" alt="Screen Shot 2021-06-09 at 5 15 00 PM" src="https://user-images.githubusercontent.com/1447339/121445429-4b1cbb80-c946-11eb-9a8e-0921956c2da5.png">

For desktop, the radius is still applied to all 4 corners – remains unchanged.
<img width="811" alt="Screen Shot 2021-06-09 at 5 17 06 PM" src="https://user-images.githubusercontent.com/1447339/121445538-85865880-c946-11eb-842e-e5960d20a395.png">


# What type of change is this?
Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Updating documentation.
- [ ] Updating deployment/build pipeline.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

# UI Checklist
- [ ] I have conducted visual UAT on my changes/features.
- [ ] My solution works well on desktop, tablet, and mobile browsers.