### PR TITLE
fix(SelectInputNative): option color inherited from select

### DIFF
--- a/src/components/SelectInputNative/SelectInputNative.tsx
+++ b/src/components/SelectInputNative/SelectInputNative.tsx
@@ -99,6 +99,7 @@ export const SelectInputNative: React.FC<SelectInputNativeProps> = ({
               value={option.value}
               disabled={option.value === ''}
               hidden={option.value === ''}
+              color={option.value === '' ? 'grey-light' : 'dark'}
             >
               {option.label}
             </Box>


### PR DESCRIPTION
# Github Issue or Trello Card
This PR addresses this issue: Option color in firefox is inherited from the select an as such, will have all options get the placeholder color which is too light.

# What type of change is this?
Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Updating documentation.
- [ ] Updating deployment/build pipeline.

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes

# UI Checklist
- [X] I have conducted visual UAT on my changes/features.
- [X] My solution works well on desktop, tablet, and mobile browsers.