### PR TITLE
Form label error styling

### DIFF
--- a/src/components/CheckboxInput/CheckboxInput.test.jsx
+++ b/src/components/CheckboxInput/CheckboxInput.test.jsx
@@ -45,7 +45,6 @@ describe('CheckboxInput', () => {
     expect(FormLabel).toHaveBeenCalledWith(
       {
         inputId: 'testCheckbox',
-        hasError: false,
         helpText: 'i am help text',
         isFieldRequired: false,
         children: 'test checkbox',
@@ -71,7 +70,6 @@ describe('CheckboxInput', () => {
     expect(FormLabel).toHaveBeenCalledWith(
       {
         inputId: 'testCheckbox',
-        hasError: false,
         helpText: undefined,
         isFieldRequired: true,
         children: 'test checkbox',
@@ -138,7 +136,6 @@ describe('CheckboxInput', () => {
       expect(FormLabel).toHaveBeenCalledWith(
         {
           inputId: 'testCheckbox',
-          hasError: true,
           helpText: undefined,
           isFieldRequired: false,
           children: 'test checkbox',
@@ -163,7 +160,6 @@ describe('CheckboxInput', () => {
       expect(FormLabel).toHaveBeenCalledWith(
         {
           inputId: 'testCheckbox',
-          hasError: true,
           helpText: undefined,
           isFieldRequired: false,
           children: 'test checkbox',
@@ -189,7 +185,6 @@ describe('CheckboxInput', () => {
     expect(FormLabel).toHaveBeenCalledWith(
       {
         inputId: 'testCheckbox',
-        hasError: false,
         helpText: undefined,
         isFieldRequired: false,
         children: 'test checkbox',
@@ -215,7 +210,6 @@ describe('CheckboxInput', () => {
       expect(FormLabel).toHaveBeenCalledWith(
         {
           inputId: 'testCheckbox',
-          hasError: false,
           helpText: undefined,
           isFieldRequired: false,
           children: 'test checkbox',
@@ -239,7 +233,6 @@ describe('CheckboxInput', () => {
       expect(FormLabel).toHaveBeenCalledWith(
         {
           inputId: 'testCheckbox',
-          hasError: false,
           helpText: undefined,
           isFieldRequired: false,
           children: 'test checkbox',

--- a/src/components/CheckboxInput/CheckboxInput.tsx
+++ b/src/components/CheckboxInput/CheckboxInput.tsx
@@ -119,7 +119,6 @@ export const CheckboxInput: React.FC<CheckboxInputProps> = ({
   const labelProps = {
     isFieldRequired: isRequired,
     inputId: id,
-    hasError: !!error,
     helpText,
     isDisabled,
     margin: labelMargin,

--- a/src/components/FormControl/FormControl.tsx
+++ b/src/components/FormControl/FormControl.tsx
@@ -53,7 +53,6 @@ export const FormControl = React.forwardRef<HTMLDivElement, FormControlProps>((
   const labelProps = {
     isFieldRequired: isRequired,
     inputId: id,
-    hasError: !!error,
     helpText,
     margin: '0 0 xs 0',
     isDisabled,

--- a/src/components/FormLabel/FormLabel.Overview.stories.mdx
+++ b/src/components/FormLabel/FormLabel.Overview.stories.mdx
@@ -13,15 +13,25 @@ import { Box } from '../Box/Box';
 
 # FormLabel
 
-FormLabel is a sub component of many of our inputs, and is meant to be paired with a form input.
+FormLabel is a sub component of many of our inputs, and is meant to be paired with a form input. In most cases, the label will have already been built into another component as a prop. However, you can use it on its own or with another component.
 
 <Canvas isExpanded>
   <FormLabel>Form Label</FormLabel>
 </Canvas>
 
+
 ## Props
 
 <ArgsTable of={FormLabel} />
+
+## Accessibility
+
+- Each label requires the `inputId` prop that equals the id of the associated input so that the `htmlFor` property can be set.
+- Don't use placeholder text as a replacement for labels. It can be used to provide an example to users, but will disappear from the field when a user enters text. It's also not broadly supported by assistive technologies and won't display in older browsers.
+- Use one of 3 ways to label a form field in order of most preferred:
+  1. Visible label with Label
+  2. Visible label that's associated to the input with aria-labelledby
+  3. Label directly using aria-label
 
 ## Examples
 
@@ -53,21 +63,6 @@ A label for an input that is required is marked with an asterisk.
     <FormLabel inputId="required" isFieldRequired>
       Required input label
     </FormLabel>
-  </Story>
-</Canvas>
-
-### Error States
-
-<Canvas>
-  <Story name="Error States">
-    <Box childGap="md">
-      <FormLabel inputId="error1" hasError helpText="This is helpful text">
-        Label with error
-      </FormLabel>
-      <FormLabel inputId="error2" hasError isFieldRequired helpText="This is helpful text">
-        Required input label has error
-      </FormLabel>
-    </Box>
   </Story>
 </Canvas>
 

--- a/src/components/FormLabel/FormLabel.Playground.stories.tsx
+++ b/src/components/FormLabel/FormLabel.Playground.stories.tsx
@@ -12,9 +12,6 @@ export default {
     displayInline: {
       control: 'boolean',
     },
-    hasError: {
-      control: 'boolean',
-    },
     helpText: {
       control: 'text',
     },

--- a/src/components/FormLabel/FormLabel.module.scss
+++ b/src/components/FormLabel/FormLabel.module.scss
@@ -15,14 +15,6 @@
     color: var(--color-brand-grey-light);
   }
 
-  &.error {
-    color: var(--color-brand-danger-base);
-
-    &.disabled {
-      color: var(--color-brand-danger-lighter);
-    }
-  }
-
   .help-text {
     margin-top: var(--form-control-help-margin);
     font-weight: 400;

--- a/src/components/FormLabel/FormLabel.test.jsx
+++ b/src/components/FormLabel/FormLabel.test.jsx
@@ -19,15 +19,13 @@ describe('FormLabel', () => {
   });
 
   test('Label correctly renders with askterisk if field is required', () => {
-    render(<FormLabel inputId="myId" isFieldRequired>my label</FormLabel>);
+    render(
+      <FormLabel inputId="myId" isFieldRequired>
+        my label
+      </FormLabel>,
+    );
     const labelElement = screen.getByText('my label *');
     expect(labelElement).toBeInTheDocument();
-  });
-
-  test('Label correctly renders with error class if field has eror', () => {
-    render(<FormLabel inputId="myId">my label</FormLabel>);
-    const labelElement = screen.getByText('my label');
-    expect(labelElement.getAttribute('class')).toContain('error');
   });
 
   test('correctly assigns an id when given an inputId', () => {
@@ -37,7 +35,11 @@ describe('FormLabel', () => {
   });
 
   test('renders help text if provided', () => {
-    const { getByText } = render(<FormLabel inputId="myId" helpText="i am help text">my label</FormLabel>);
+    const { getByText } = render(
+      <FormLabel inputId="myId" helpText="i am help text">
+        my label
+      </FormLabel>,
+    );
     expect(getByText('i am help text')).toBeDefined();
   });
 });

--- a/src/components/FormLabel/FormLabel.test.jsx
+++ b/src/components/FormLabel/FormLabel.test.jsx
@@ -25,13 +25,13 @@ describe('FormLabel', () => {
   });
 
   test('Label correctly renders with error class if field has eror', () => {
-    render(<FormLabel inputId="myId" hasError>my label</FormLabel>);
+    render(<FormLabel inputId="myId">my label</FormLabel>);
     const labelElement = screen.getByText('my label');
     expect(labelElement.getAttribute('class')).toContain('error');
   });
 
   test('correctly assigns an id when given an inputId', () => {
-    render(<FormLabel inputId="myId" hasError>my label</FormLabel>);
+    render(<FormLabel inputId="myId">my label</FormLabel>);
     const labelElement = screen.getByText('my label');
     expect(labelElement).toHaveAttribute('id', 'myIdLabel');
   });

--- a/src/components/FormLabel/FormLabel.tsx
+++ b/src/components/FormLabel/FormLabel.tsx
@@ -21,10 +21,6 @@ export interface FormLabelProps {
    */
   displayInline?: boolean;
   /**
-   * Mark the label has invalid
-   */
-  hasError?: boolean;
-  /**
    * Additional clarifying text to that helps describe the field
    */
   helpText?: ReactNode;
@@ -52,7 +48,6 @@ export const FormLabel: FC<FormLabelProps> = ({
   className = '',
   displayInline = false,
   display = 'block',
-  hasError = false,
   helpText,
   isDisabled = false,
   isFieldRequired = false,
@@ -63,7 +58,6 @@ export const FormLabel: FC<FormLabelProps> = ({
 }) => {
   const labelClasses = classNames(styles.label, className, {
     [styles.disabled]: isDisabled,
-    [styles.error]: hasError,
     [styles.disabled]: isDisabled,
     [styles.inline]: displayInline,
     [styles['radio-input-label']]: isRadioInputLabel,

--- a/src/components/Formik/FormikTextInput/FormikTextInput.test.jsx
+++ b/src/components/Formik/FormikTextInput/FormikTextInput.test.jsx
@@ -1,10 +1,5 @@
 import React from 'react';
-import {
-  render,
-  fireEvent,
-  screen,
-  waitFor,
-} from '@testing-library/react';
+import { render, fireEvent, screen, waitFor } from '@testing-library/react';
 import { Formik, Field, Form } from 'formik';
 import { FormikTextInput } from './FormikTextInput';
 
@@ -65,7 +60,9 @@ describe('FormikTextInput', () => {
       });
 
       test('Input correctly assigns autocomplete value of "off" when incorrect type is provided', () => {
-        const { getByDisplayValue } = render(renderForm('hello', { autoComplete: ['a', 'random', 'array'] }));
+        const { getByDisplayValue } = render(
+          renderForm('hello', { autoComplete: ['a', 'random', 'array'] }),
+        );
         const inputElement = getByDisplayValue('hello');
         expect(inputElement).toHaveAttribute('autocomplete', 'off');
       });
@@ -116,9 +113,11 @@ describe('FormikTextInput', () => {
 
   describe('Callback Handling', () => {
     describe('onChange', () => {
-      test('Custom onChange event fires callback function, overwriting Formik\'s onChange', () => {
+      test("Custom onChange event fires callback function, overwriting Formik's onChange", () => {
         let value = '';
-        const mockedHandleChange = jest.fn(event => { value = event.target.value; });
+        const mockedHandleChange = jest.fn(event => {
+          value = event.target.value;
+        });
 
         const { getByLabelText } = render(renderForm(value, { onChange: mockedHandleChange }));
         const input = getByLabelText(testLabelName);
@@ -135,15 +134,9 @@ describe('FormikTextInput', () => {
     describe('Form Label', () => {
       test('Input correctly passes props to dependency label component', async () => {
         const { getByText } = render(renderForm('', { isRequired: true }));
-        const submitButton = getByText('submit');
         const labelElement = getByText(`${testLabelName} *`);
         expect(labelElement).toHaveAttribute('for', testLabelName);
         expect(labelElement).toBeInTheDocument();
-
-        fireEvent.click(submitButton);
-        await waitFor(() => {
-          expect(labelElement.getAttribute('class')).toContain('error');
-        });
       });
     });
   });

--- a/src/components/Formik/FormikTextareaInput/FormikTextareaInput.test.tsx
+++ b/src/components/Formik/FormikTextareaInput/FormikTextareaInput.test.tsx
@@ -1,22 +1,12 @@
 import React from 'react';
-import {
-  render,
-  fireEvent,
-  screen,
-  waitFor,
-} from '@testing-library/react';
-import {
-  Formik,
-  Field,
-  Form,
-  FormikValues,
-} from 'formik';
+import { render, fireEvent, screen, waitFor } from '@testing-library/react';
+import { Formik, Field, Form, FormikValues } from 'formik';
 import { FormikTextareaInput } from './FormikTextareaInput';
 
 const testLabelName = 'textInput';
 
 const handleValidation = (values: FormikValues) => {
-  const errors: { [testLabelName]?: string; } = {};
+  const errors: { [testLabelName]?: string } = {};
   if (!values[testLabelName]) {
     errors[testLabelName] = 'input is required';
   }
@@ -31,7 +21,7 @@ type FormProps = {
   hideLabel?: boolean;
   onChange?: jest.Mock<void, [any]>; // eslint-disable-line
   autoFocus?: boolean;
-}
+};
 
 const renderForm = (initialValue: string | undefined, props: FormProps) => (
   <Formik
@@ -80,7 +70,9 @@ describe('FormikTextareaInput', () => {
       });
 
       test('Input correctly assigns autocomplete value of "off" when incorrect type is provided', () => {
-        const { getByDisplayValue } = render(renderForm('hello', { autoComplete: ['a', 'random', 'array'] }));
+        const { getByDisplayValue } = render(
+          renderForm('hello', { autoComplete: ['a', 'random', 'array'] }),
+        );
         const inputElement = getByDisplayValue('hello');
         expect(inputElement).toHaveAttribute('autocomplete', 'off');
       });
@@ -131,9 +123,11 @@ describe('FormikTextareaInput', () => {
 
   describe('Callback Handling', () => {
     describe('onChange', () => {
-      test('Custom onChange event fires callback function, overwriting Formik\'s onChange', () => {
+      test("Custom onChange event fires callback function, overwriting Formik's onChange", () => {
         let value = '';
-        const mockedHandleChange = jest.fn(event => { value = event.target.value; });
+        const mockedHandleChange = jest.fn(event => {
+          value = event.target.value;
+        });
 
         const { getByLabelText } = render(renderForm(value, { onChange: mockedHandleChange }));
         const input = getByLabelText(testLabelName);
@@ -150,15 +144,9 @@ describe('FormikTextareaInput', () => {
     describe('Form Label', () => {
       test('Input correctly passes props to dependency label component', async () => {
         const { getByText } = render(renderForm('', { isRequired: true }));
-        const submitButton = getByText('submit');
         const labelElement = getByText(`${testLabelName} *`);
         expect(labelElement).toHaveAttribute('for', testLabelName);
         expect(labelElement).toBeInTheDocument();
-
-        fireEvent.click(submitButton);
-        await waitFor(() => {
-          expect(labelElement.getAttribute('class')).toContain('error');
-        });
       });
     });
   });

--- a/src/components/Formik/FormikTextareaInput/FormikTextareaInput.test.tsx
+++ b/src/components/Formik/FormikTextareaInput/FormikTextareaInput.test.tsx
@@ -1,12 +1,16 @@
 import React from 'react';
-import { render, fireEvent, screen, waitFor } from '@testing-library/react';
-import { Formik, Field, Form, FormikValues } from 'formik';
+import {
+  render, fireEvent, screen, waitFor,
+} from '@testing-library/react';
+import {
+  Formik, Field, Form, FormikValues,
+} from 'formik';
 import { FormikTextareaInput } from './FormikTextareaInput';
 
 const testLabelName = 'textInput';
 
 const handleValidation = (values: FormikValues) => {
-  const errors: { [testLabelName]?: string } = {};
+  const errors: { [testLabelName]?: string; } = {};
   if (!values[testLabelName]) {
     errors[testLabelName] = 'input is required';
   }

--- a/src/components/RadioGroup/RadioGroup.module.scss
+++ b/src/components/RadioGroup/RadioGroup.module.scss
@@ -17,10 +17,6 @@
         color: var(--form-control-description-color);
         font-weight: 400;
       }
-
-      &.error {
-        color: var(--form-control-error-color);
-      }
     }
   }
 }

--- a/src/components/RadioGroup/RadioGroup.tsx
+++ b/src/components/RadioGroup/RadioGroup.tsx
@@ -87,15 +87,11 @@ export const RadioGroup: FC<RadioGroupProps> = ({
     [styles.loading]: error,
   });
 
-  const legendClasses = classNames(styles.legend, {
-    [styles.error]: error,
-  });
-
   return (
     <div className={classNames(styles['radio-group'], groupClasses)}>
       <fieldset className={styles.fieldset}>
         {(title || description) && (
-          <legend className={legendClasses}>
+          <legend className={styles.legend}>
             {title}
             {isRequired && <span>&nbsp;*</span>}
             {description && <div className={styles.description}>{description}</div>}

--- a/src/components/RadioGroup/RadioGroup.tsx
+++ b/src/components/RadioGroup/RadioGroup.tsx
@@ -109,7 +109,6 @@ export const RadioGroup: FC<RadioGroupProps> = ({
                 name={name}
                 onChange={onChange}
                 option={option}
-                error={error}
                 isDisabled={isDisabled || option.disabled || false}
                 isSelected={value === option.value}
                 onBlur={onBlur}

--- a/src/components/RadioGroup/RadioInput/RadioInput.tsx
+++ b/src/components/RadioGroup/RadioInput/RadioInput.tsx
@@ -1,4 +1,4 @@
-import React, { ChangeEvent, FocusEvent, ReactNode } from 'react';
+import React, { ChangeEvent, FocusEvent } from 'react';
 import classNames from 'classnames';
 import { Box } from '../../Box/Box';
 import { FormLabel } from '../../FormLabel/FormLabel';

--- a/src/components/RadioGroup/RadioInput/RadioInput.tsx
+++ b/src/components/RadioGroup/RadioInput/RadioInput.tsx
@@ -80,7 +80,6 @@ export const RadioInput = React.forwardRef<HTMLDivElement, RadioInputProps>((
     inputId: option.id,
     isDisabled,
     displayInline: true,
-    hasError: !!error,
     isRadioInputLabel: true,
   };
 

--- a/src/components/RadioGroup/RadioInput/RadioInput.tsx
+++ b/src/components/RadioGroup/RadioInput/RadioInput.tsx
@@ -27,11 +27,6 @@ export interface RadioInputProps {
    */
   className?: string;
   /**
-   * Mark the radio group as invalid and display a validation message.
-   * Pass a string or node to render a validation message below the input.
-   */
-  error?: ReactNode;
-  /**
    * If the radio group should be disabled and not focusable.
    */
   isDisabled?: boolean;
@@ -59,7 +54,6 @@ export const RadioInput = React.forwardRef<HTMLDivElement, RadioInputProps>((
     onChange,
     option,
     className = '',
-    error = false,
     isDisabled = false,
     isHidden = false,
     isSelected = false,

--- a/src/components/SelectInput/SelectInput.tsx
+++ b/src/components/SelectInput/SelectInput.tsx
@@ -161,7 +161,6 @@ export const SelectInput: FC<SelectInputProps> = ({
   const labelProps = {
     isFieldRequired: isRequired,
     inputId: id,
-    hasError: !!error,
     helpText,
     className: styles['select-input-label'],
     isDisabled,

--- a/src/components/TextInput/TextInput.test.tsx
+++ b/src/components/TextInput/TextInput.test.tsx
@@ -190,14 +190,6 @@ describe('TextInput', () => {
     });
 
     describe('Error', () => {
-      test('the label renders in an error state', () => {
-        render(<TextInput {...baseProps} error="You silly goose" />);
-
-        const labelElement = screen.getByText(baseProps.label);
-
-        expect(labelElement.getAttribute('class')).toContain('error');
-      });
-
       test('Input correctly displays error message if provided', () => {
         render(<TextInput {...baseProps} error="You silly goose" />);
 

--- a/src/components/TextareaInput/TextareaInput.test.tsx
+++ b/src/components/TextareaInput/TextareaInput.test.tsx
@@ -123,14 +123,6 @@ describe('TextareaInput', () => {
     });
 
     describe('Error', () => {
-      test('the label renders in an error state', () => {
-        render(<TextareaInput {...baseProps} error="You silly goose" />);
-
-        const labelElement = screen.getByText(baseProps.label);
-
-        expect(labelElement.getAttribute('class')).toContain('error');
-      });
-
       test('Input correctly displays error message if provided', () => {
         render(<TextareaInput {...baseProps} error="You silly goose" />);
 

--- a/src/components/TextareaInput/TextareaInput.tsx
+++ b/src/components/TextareaInput/TextareaInput.tsx
@@ -143,7 +143,6 @@ export const TextareaInput: FC<TextareaInputProps> = ({
   const labelProps = {
     isFieldRequired: isRequired,
     inputId: id,
-    hasError: !!error,
     helpText,
     className: styles['textarea-input-label'],
     isDisabled,

--- a/src/components/Toggle/Toggle.tsx
+++ b/src/components/Toggle/Toggle.tsx
@@ -115,7 +115,6 @@ export const Toggle: FC<ToggleProps> = ({
     isFieldRequired: isRequired,
     className: styles['toggle-label'],
     inputId: id,
-    hasError: !!error,
     isDisabled,
   };
 


### PR DESCRIPTION
# Github Issue or Trello Card
This PR addresses this issue: https://trello.com/c/kqgoPlHl/714-form-input-error-state-styling

For all form inputs, updates the "error" state so that the label remains dark grey instead of changing to red. 

Before
<img width="978" alt="Screen Shot 2021-07-06 at 9 23 49 AM" src="https://user-images.githubusercontent.com/1447339/124635101-e9b01580-de3b-11eb-85e6-28bcfbc4421b.png">

After PR
<img width="989" alt="Screen Shot 2021-07-06 at 9 23 52 AM" src="https://user-images.githubusercontent.com/1447339/124635119-ee74c980-de3b-11eb-8584-6da085874008.png">


# What type of change is this?
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Updating documentation.
- [ ] Updating deployment/build pipeline.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

# UI Checklist
- [x] I have conducted visual UAT on my changes/features.
- [x] My solution works well on desktop, tablet, and mobile browsers.