### PR TITLE
feat: [528] Add additional context to malformed css shorthand warning

### DIFF
--- a/src/lib/cssShorthandToClasses.ts
+++ b/src/lib/cssShorthandToClasses.ts
@@ -31,6 +31,8 @@ function generateBaseClasses(
       has extra whitespace either at the beginning or the end of it.
       We have trimmed this whitespace, but please double-check that
       the prop value is correct.
+      attribute: "${attribute}"
+      value: "${value}"
     `);
   }
 
@@ -57,6 +59,8 @@ function generateBaseClasses(
         shorthand value as a prop in your component. The value
         has more than four string components. While it will not break anything,
         please double-check your prop values to ensure the expected result is correct.
+        attribute: "${attribute}"
+        value: "${value}"
       `);
     }
 


### PR DESCRIPTION
# Github Issue or Trello Card
This PR addresses this issue: https://github.com/palmetto/palmetto-components/issues/528

# What type of change is this?
Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes