### PR TITLE
Wrap required input label's asterisk in a targetable element

### DIFF
--- a/src/components/FormLabel/FormLabel.test.jsx
+++ b/src/components/FormLabel/FormLabel.test.jsx
@@ -2,6 +2,16 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import { FormLabel } from './FormLabel';
 
+function getByTextWithMarkup(text) {
+  return (content, element) => {
+    const hasText = node => node.textContent === text;
+    const elementHasText = hasText(element);
+    const childrenDontHaveText = Array.from(element.children).every(child => !hasText(child));
+
+    return elementHasText && childrenDontHaveText;
+  };
+}
+
 beforeEach(() => {
   console.error = jest.fn(); // eslint-disable-line no-console
 });
@@ -24,7 +34,9 @@ describe('FormLabel', () => {
         my label
       </FormLabel>,
     );
-    const labelElement = screen.getByText('my label *');
+
+    const labelElement = screen.getByText(getByTextWithMarkup('my label *'));
+
     expect(labelElement).toBeInTheDocument();
   });
 

--- a/src/components/FormLabel/FormLabel.tsx
+++ b/src/components/FormLabel/FormLabel.tsx
@@ -75,7 +75,7 @@ export const FormLabel: FC<FormLabelProps> = ({
       {...restProps}
     >
       {children}
-      {isFieldRequired && <>&nbsp;*</>}
+      {isFieldRequired && <span className="field-required-asterisk">&nbsp;*</span>}
       {helpText && (
         <Box as="p" display="block" fontSize="sm" color="grey" className={styles['help-text']}>
           {helpText}

--- a/src/components/FormLabel/FormLabel.tsx
+++ b/src/components/FormLabel/FormLabel.tsx
@@ -75,7 +75,7 @@ export const FormLabel: FC<FormLabelProps> = ({
       {...restProps}
     >
       {children}
-      {isFieldRequired && <span className="field-required-asterisk">&nbsp;*</span>}
+      {isFieldRequired && <span> *</span>}
       {helpText && (
         <Box as="p" display="block" fontSize="sm" color="grey" className={styles['help-text']}>
           {helpText}

--- a/src/components/Formik/FormikSelectInput/FormikSelectInput.test.jsx
+++ b/src/components/Formik/FormikSelectInput/FormikSelectInput.test.jsx
@@ -50,6 +50,16 @@ const renderForm = (initialValue, props) => (
   </Formik>
 );
 
+function getByTextWithMarkup(text) {
+  return (content, element) => {
+    const hasText = node => node.textContent === text;
+    const elementHasText = hasText(element);
+    const childrenDontHaveText = Array.from(element.children).every(child => !hasText(child));
+
+    return elementHasText && childrenDontHaveText;
+  };
+}
+
 describe('FormikSelectInput', () => {
   describe('States', () => {
     describe('Hidden label, with a placeholder', () => {
@@ -116,7 +126,7 @@ describe('FormikSelectInput', () => {
       test('it renders an asterisk in the label', () => {
         render(renderForm([], { isRequired: true }));
 
-        expect(screen.getByText(`${testLabelName} *`)).toBeInTheDocument();
+        expect(screen.getByText(getByTextWithMarkup(`${testLabelName} *`))).toBeInTheDocument();
       });
     });
 

--- a/src/components/Formik/FormikSelectInputNative/FormikSelectInputNative.test.jsx
+++ b/src/components/Formik/FormikSelectInputNative/FormikSelectInputNative.test.jsx
@@ -50,6 +50,16 @@ const renderForm = (initialValue, props) => {
   );
 };
 
+function getByTextWithMarkup(text) {
+  return (content, element) => {
+    const hasText = node => node.textContent === text;
+    const elementHasText = hasText(element);
+    const childrenDontHaveText = Array.from(element.children).every(child => !hasText(child));
+
+    return elementHasText && childrenDontHaveText;
+  };
+}
+
 describe('SelectInputNative', () => {
   describe('States', () => {
     describe('Hidden label, with a placeholder', () => {
@@ -96,7 +106,7 @@ describe('SelectInputNative', () => {
       test('it renders an asterisk in the label', () => {
         render(renderForm(null, { isRequired: true }));
 
-        expect(screen.getByText(`${testLabelName} *`)).toBeInTheDocument();
+        expect(screen.getByText(getByTextWithMarkup(`${testLabelName} *`))).toBeInTheDocument();
       });
     });
 

--- a/src/components/Formik/FormikTextInput/FormikTextInput.test.jsx
+++ b/src/components/Formik/FormikTextInput/FormikTextInput.test.jsx
@@ -36,6 +36,16 @@ const renderForm = (initialValue, props) => (
   </Formik>
 );
 
+function getByTextWithMarkup(text) {
+  return (content, element) => {
+    const hasText = node => node.textContent === text;
+    const elementHasText = hasText(element);
+    const childrenDontHaveText = Array.from(element.children).every(child => !hasText(child));
+
+    return elementHasText && childrenDontHaveText;
+  };
+}
+
 describe('FormikTextInput', () => {
   describe('States', () => {
     describe('Autofocused', () => {
@@ -134,7 +144,7 @@ describe('FormikTextInput', () => {
     describe('Form Label', () => {
       test('Input correctly passes props to dependency label component', async () => {
         const { getByText } = render(renderForm('', { isRequired: true }));
-        const labelElement = getByText(`${testLabelName} *`);
+        const labelElement = getByText(getByTextWithMarkup(`${testLabelName} *`));
         expect(labelElement).toHaveAttribute('for', testLabelName);
         expect(labelElement).toBeInTheDocument();
       });

--- a/src/components/Formik/FormikTextareaInput/FormikTextareaInput.test.tsx
+++ b/src/components/Formik/FormikTextareaInput/FormikTextareaInput.test.tsx
@@ -50,6 +50,20 @@ const renderForm = (initialValue: string | undefined, props: FormProps) => (
   </Formik>
 );
 
+function getByTextWithMarkup(text: string) {
+  // eslint-disable-next-line
+  // @ts-ignore
+  return (content, element) => {
+    const hasText = (node: Element) => node.textContent === text;
+    const elementHasText = hasText(element);
+    // eslint-disable-next-line
+    // @ts-ignore
+    const childrenDontHaveText = Array.from(element.children).every(child => !hasText(child));
+
+    return elementHasText && childrenDontHaveText;
+  };
+}
+
 describe('FormikTextareaInput', () => {
   describe('States', () => {
     describe('Autofocused', () => {
@@ -148,7 +162,7 @@ describe('FormikTextareaInput', () => {
     describe('Form Label', () => {
       test('Input correctly passes props to dependency label component', async () => {
         const { getByText } = render(renderForm('', { isRequired: true }));
-        const labelElement = getByText(`${testLabelName} *`);
+        const labelElement = getByText(getByTextWithMarkup(`${testLabelName} *`));
         expect(labelElement).toHaveAttribute('for', testLabelName);
         expect(labelElement).toBeInTheDocument();
       });

--- a/src/components/Formik/FormikTimePicker/FormikTimePicker.test.tsx
+++ b/src/components/Formik/FormikTimePicker/FormikTimePicker.test.tsx
@@ -55,6 +55,20 @@ const renderForm = (
   </Formik>
 );
 
+function getByTextWithMarkup(text: string) {
+  // eslint-disable-next-line
+  // @ts-ignore
+  return (content, element) => {
+    const hasText = (node: Element) => node.textContent === text;
+    const elementHasText = hasText(element);
+    // eslint-disable-next-line
+    // @ts-ignore
+    const childrenDontHaveText = Array.from(element.children).every(child => !hasText(child));
+
+    return elementHasText && childrenDontHaveText;
+  };
+}
+
 describe('FormikTimePicker', () => {
   describe('States', () => {
     describe('Hidden label, with a placeholder', () => {
@@ -129,7 +143,7 @@ describe('FormikTimePicker', () => {
       test('it renders an asterisk in the label', () => {
         render(renderForm([], { isRequired: true }));
 
-        expect(screen.getByText(`${testLabelName} *`)).toBeInTheDocument();
+        expect(screen.getByText(getByTextWithMarkup(`${testLabelName} *`))).toBeInTheDocument();
       });
     });
 

--- a/src/components/Formik/FormikTimePickerNative/FormikTimePickerNative.test.tsx
+++ b/src/components/Formik/FormikTimePickerNative/FormikTimePickerNative.test.tsx
@@ -52,6 +52,20 @@ const renderForm = (
   </Formik>
 );
 
+function getByTextWithMarkup(text: string) {
+  // eslint-disable-next-line
+  // @ts-ignore
+  return (content, element) => {
+    const hasText = (node: Element) => node.textContent === text;
+    const elementHasText = hasText(element);
+    // eslint-disable-next-line
+    // @ts-ignore
+    const childrenDontHaveText = Array.from(element.children).every(child => !hasText(child));
+
+    return elementHasText && childrenDontHaveText;
+  };
+}
+
 describe('FormikTimePickerNative', () => {
   describe('States', () => {
     describe('Hidden label, with a placeholder', () => {
@@ -98,7 +112,7 @@ describe('FormikTimePickerNative', () => {
       test('it renders an asterisk in the label', () => {
         render(renderForm(null, { isRequired: true }));
 
-        expect(screen.getByText(`${testLabelName} *`)).toBeInTheDocument();
+        expect(screen.getByText(getByTextWithMarkup(`${testLabelName} *`))).toBeInTheDocument();
       });
     });
 

--- a/src/components/SelectInput/SelectInput.test.jsx
+++ b/src/components/SelectInput/SelectInput.test.jsx
@@ -9,6 +9,16 @@ const selectOptions = [
   { value: 'vanilla', label: 'Vanilla' },
 ];
 
+function getByTextWithMarkup(text) {
+  return (content, element) => {
+    const hasText = node => node.textContent === text;
+    const elementHasText = hasText(element);
+    const childrenDontHaveText = Array.from(element.children).every(child => !hasText(child));
+
+    return elementHasText && childrenDontHaveText;
+  };
+}
+
 describe('SelectInput', () => {
   describe('Callback Handling', () => {
     test('it fires onChange callback on change', async () => {
@@ -196,7 +206,7 @@ describe('SelectInput', () => {
           />,
         );
 
-        expect(screen.getByText('Select Label *')).toBeInTheDocument();
+        expect(screen.getByText(getByTextWithMarkup('Select Label *'))).toBeInTheDocument();
       });
     });
 

--- a/src/components/SelectInputNative/SelectInputNative.test.tsx
+++ b/src/components/SelectInputNative/SelectInputNative.test.tsx
@@ -8,6 +8,20 @@ const selectOptions = [
   { value: 'vanilla', label: 'Vanilla' },
 ];
 
+function getByTextWithMarkup(text: string) {
+  // eslint-disable-next-line
+  // @ts-ignore
+  return (content, element) => {
+    const hasText = (node: Element) => node.textContent === text;
+    const elementHasText = hasText(element);
+    // eslint-disable-next-line
+    // @ts-ignore
+    const childrenDontHaveText = Array.from(element.children).every(child => !hasText(child));
+
+    return elementHasText && childrenDontHaveText;
+  };
+}
+
 describe('SelectInputNative', () => {
   describe('Callback Handling', () => {
     test('it fires onChange callback on change', async () => {
@@ -184,7 +198,7 @@ describe('SelectInputNative', () => {
           />,
         );
 
-        expect(screen.getByText('Select Label *')).toBeInTheDocument();
+        expect(screen.getByText(getByTextWithMarkup('Select Label *'))).toBeInTheDocument();
       });
     });
 

--- a/src/components/TextInput/TextInput.test.tsx
+++ b/src/components/TextInput/TextInput.test.tsx
@@ -11,6 +11,20 @@ const baseProps = {
   onClear: undefined,
 };
 
+function getByTextWithMarkup(text: string) {
+  // eslint-disable-next-line
+  // @ts-ignore
+  return (content, element) => {
+    const hasText = (node: Element) => node.textContent === text;
+    const elementHasText = hasText(element);
+    // eslint-disable-next-line
+    // @ts-ignore
+    const childrenDontHaveText = Array.from(element.children).every(child => !hasText(child));
+
+    return elementHasText && childrenDontHaveText;
+  };
+}
+
 describe('TextInput', () => {
   describe('Callback Handling', () => {
     describe('onChange', () => {
@@ -183,7 +197,7 @@ describe('TextInput', () => {
       test("it's label renders an asterisk indicating that it's required", () => {
         render(<TextInput {...baseProps} isRequired />);
 
-        const labelElement = screen.getByText(`${baseProps.label} *`);
+        const labelElement = screen.getByText(getByTextWithMarkup(`${baseProps.label} *`));
 
         expect(labelElement).toBeInTheDocument();
       });

--- a/src/components/TextareaInput/TextareaInput.test.tsx
+++ b/src/components/TextareaInput/TextareaInput.test.tsx
@@ -10,6 +10,20 @@ const baseProps = {
   onChange: () => null,
 };
 
+function getByTextWithMarkup(text: string) {
+  // eslint-disable-next-line
+  // @ts-ignore
+  return (content, element) => {
+    const hasText = (node: Element) => node.textContent === text;
+    const elementHasText = hasText(element);
+    // eslint-disable-next-line
+    // @ts-ignore
+    const childrenDontHaveText = Array.from(element.children).every(child => !hasText(child));
+
+    return elementHasText && childrenDontHaveText;
+  };
+}
+
 describe('TextareaInput', () => {
   describe('Callback Handling', () => {
     describe('onChange', () => {
@@ -116,7 +130,7 @@ describe('TextareaInput', () => {
       test("it's label renders an asterisk indicating that it's required", () => {
         render(<TextareaInput {...baseProps} isRequired />);
 
-        const labelElement = screen.getByText(`${baseProps.label} *`);
+        const labelElement = screen.getByText(getByTextWithMarkup(`${baseProps.label} *`));
 
         expect(labelElement).toBeInTheDocument();
       });


### PR DESCRIPTION
# Github Issue or Trello Card
This PR addresses this issue: https://github.com/palmetto/helios-app/pull/231

On the app's login page, we wanted to require the Email and Password fields, but _not_ show the asterisk in the labels, as it's generally understood that all fields in a login form are required.

Wrapping the asterisk in a required field's label with a `span` and a class makes it a cinch to hide it with CSS, without requiring additional prop plumbing.

# What type of change is this?
- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

# UI Checklist
- [x] I have conducted visual UAT on my changes/features.
- [x] My solution works well on desktop, tablet, and mobile browsers.