### PR TITLE
Remove background color from text input on focus

### DIFF
--- a/src/components/TextInput/TextInput.module.scss
+++ b/src/components/TextInput/TextInput.module.scss
@@ -51,7 +51,6 @@
 
     &:focus {
       outline: none;
-      background-color: var(--form-control-background-color);
     }
 
     &:disabled {


### PR DESCRIPTION
# Github Issue or Trello Card
This PR addresses this issue: [Text inputs are janky on iOS](https://trello.com/c/hXR5vDGD/1041-text-inputs-are-janky-on-ios)

This PR removes the background color from text inputs on focus to prevent this overflow behavior on mobile. Here is a screenshot of the issue:
![image](https://user-images.githubusercontent.com/16456162/126386556-3a6388b1-375c-42e5-bd69-17c13ec4b8f6.png)


# What type of change is this?
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Updating documentation.
- [ ] Updating deployment/build pipeline.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

# UI Checklist
- [x] I have conducted visual UAT on my changes/features.
- [x] My solution works well on desktop, tablet, and mobile browsers.