### PR TITLE
refactor(Toggle): separate sub-component usage and add more visual tests

### DIFF
--- a/src/components/Toggle/Toggle.VisualTests.stories.tsx
+++ b/src/components/Toggle/Toggle.VisualTests.stories.tsx
@@ -1,0 +1,77 @@
+import React, { ReactElement, useState } from 'react';
+import { Meta, Story } from '@storybook/react/types-6-0';
+import { Toggle, ToggleProps } from './Toggle';
+import { TOGGLE_SIZES } from './Toggle.constants';
+import { Box } from '../Box/Box';
+
+export default {
+  title: 'Components/Toggle/Visual Regression Tests',
+  component: Toggle,
+} as Meta;
+
+const Template: Story<ToggleProps> = args => (
+  <Box childGap="xl">
+    {TOGGLE_SIZES.map(size => (
+      <Box childGap="md" key={`${args.id}-${size}`}>
+        <Toggle
+          {...args}
+          id={`${args.id}-${size}-checked`}
+          label="I agree to the Terms and Conditions and Privacy Policy"
+          isChecked
+          size={size}
+          onChange={() => {}} // eslint-disable-line
+        />
+        <Toggle
+          {...args}
+          id={`${args.id}-${size}-unchecked`}
+          label="I agree to the Terms and Conditions and Privacy Policy"
+          size={size}
+          onChange={() => {}} // eslint-disable-line
+        />
+      </Box>
+    ))}
+  </Box>
+);
+
+export const AllSizes = Template.bind({});
+AllSizes.args = { id: 'AllSizes' };
+
+export const AllSizesRequired = Template.bind({});
+AllSizesRequired.args = { id: 'AllSizesRequired', isRequired: true };
+
+export const AllSizesError = Template.bind({});
+AllSizesError.args = { id: 'AllSizesError', error: 'Agreement is required' };
+
+export const AllSizesDisabled = Template.bind({});
+AllSizesDisabled.args = { id: 'AllSizesDisabled', isDisabled: true };
+
+export const AllSizesHideLabel = Template.bind({});
+AllSizesHideLabel.args = { id: 'AllSizesHideLabel', hideLabel: true };
+
+export const AllSizesHideLabelError = Template.bind({});
+AllSizesHideLabelError.args = {
+  id: 'AllSizesHideLabelError',
+  hideLabel: true,
+  error: 'Agreement is required',
+};
+
+export const AllSizesWithHelpText = Template.bind({});
+AllSizesWithHelpText.args = {
+  id: 'AllSizesWithHelpText',
+  helpText: 'This is helpful text',
+};
+
+export const AllSizesWithHelpTextRequired = Template.bind({});
+AllSizesWithHelpTextRequired.args = {
+  id: 'AllSizesWithHelpTextRequired',
+  helpText: 'This is helpful text',
+  isRequired: true,
+};
+
+export const AllSizesWithHelpTextRequiredError = Template.bind({});
+AllSizesWithHelpTextRequiredError.args = {
+  id: 'AllSizesWithHelpTextRequired',
+  helpText: 'This is helpful text',
+  isRequired: true,
+  error: 'Agreement is required',
+};

--- a/src/components/Toggle/Toggle.VisualTests.stories.tsx
+++ b/src/components/Toggle/Toggle.VisualTests.stories.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, useState } from 'react';
+import React from 'react';
 import { Meta, Story } from '@storybook/react/types-6-0';
 import { Toggle, ToggleProps } from './Toggle';
 import { TOGGLE_SIZES } from './Toggle.constants';

--- a/src/components/Toggle/Toggle.VisualTests.stories.tsx
+++ b/src/components/Toggle/Toggle.VisualTests.stories.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Meta, Story } from '@storybook/react/types-6-0';
 import { Toggle, ToggleProps } from './Toggle';
-import { TOGGLE_SIZES } from './Toggle.constants';
+import TOGGLE_SIZES from './Toggle.constants';
 import { Box } from '../Box/Box';
 
 export default {

--- a/src/components/Toggle/Toggle.constants.ts
+++ b/src/components/Toggle/Toggle.constants.ts
@@ -1,0 +1,3 @@
+import { ToggleSize } from './Toggle';
+
+export const TOGGLE_SIZES: ToggleSize[] = ['sm', 'md', 'lg'];

--- a/src/components/Toggle/Toggle.constants.ts
+++ b/src/components/Toggle/Toggle.constants.ts
@@ -1,3 +1,5 @@
 import { ToggleSize } from './Toggle';
 
-export const TOGGLE_SIZES: ToggleSize[] = ['sm', 'md', 'lg'];
+const TOGGLE_SIZES: ToggleSize[] = ['sm', 'md', 'lg'];
+
+export default TOGGLE_SIZES;

--- a/src/components/Toggle/Toggle.module.scss
+++ b/src/components/Toggle/Toggle.module.scss
@@ -98,9 +98,3 @@
     box-shadow: none;
   }
 }
-
-.toggle-label {
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-}

--- a/src/components/Toggle/Toggle.test.jsx
+++ b/src/components/Toggle/Toggle.test.jsx
@@ -37,6 +37,32 @@ describe('Toggle', () => {
     expect(getByLabelText('test label')).toHaveAttribute('aria-labelledby', 'testInputLabel');
   });
 
+  test('aria-label is assigned if label is hidden', () => {
+    const { getByLabelText } = render(
+      <Toggle
+        id="testInput"
+        label="hidden test label"
+        hideLabel
+        value="hello"
+        onChange={() => null}
+      />,
+    );
+    expect(getByLabelText('hidden test label')).toBeInTheDocument();
+  });
+
+  test('HelpText is rendered when set', () => {
+    const { getByText } = render(
+      <Toggle
+        id="testInput"
+        label="test label"
+        helpText="help text"
+        value="hello"
+        onChange={() => null}
+      />,
+    );
+    expect(getByText('help text')).toBeInTheDocument();
+  });
+
   describe('error states', () => {
     test('renders error message if error exists and is not true', () => {
       const { getByText } = render(

--- a/src/components/Toggle/Toggle.tsx
+++ b/src/components/Toggle/Toggle.tsx
@@ -7,6 +7,7 @@ import { FormLabel } from '../FormLabel/FormLabel';
 import { Box } from '../Box/Box';
 import styles from './Toggle.module.scss';
 
+export type ToggleSize = 'sm' | 'md' | 'lg';
 export interface ToggleProps {
   /**
    * The id attribute of the input.
@@ -61,7 +62,7 @@ export interface ToggleProps {
   /**
    * The size of the toggle.
    */
-  size?: 'sm' | 'md' | 'lg';
+  size?: ToggleSize;
 }
 
 export const Toggle: FC<ToggleProps> = ({

--- a/src/components/Toggle/Toggle.tsx
+++ b/src/components/Toggle/Toggle.tsx
@@ -98,9 +98,10 @@ export const Toggle: FC<ToggleProps> = ({
   const thumbClasses = classNames(styles['toggle-thumb'], styles[`thumb-${size}`]);
 
   const inputProps = {
+    'aria-required': isRequired,
     'aria-invalid': !!error,
     'aria-label': label,
-    'aria-labelledby': `${id}Label`,
+    'aria-labelledby': label && !hideLabel ? `${id}Label` : undefined,
     id,
     checked: !!isChecked,
     disabled: isDisabled,
@@ -113,30 +114,25 @@ export const Toggle: FC<ToggleProps> = ({
 
   const labelProps = {
     isFieldRequired: isRequired,
-    className: styles['toggle-label'],
     inputId: id,
     isDisabled,
+    helpText,
+    className: helpText && (size === 'md' || size === 'lg') ? 'm-top-2xs' : '',
   };
 
   return (
     <Box className={className}>
-      <Box display="inline-block" className={wrapperClasses}>
-        <FormLabel {...labelProps}>
-          <input {...inputProps} />
-          <span aria-hidden="true" className={trackClasses}>
-            <span className={thumbClasses} />
-          </span>
-          {!hideLabel && (
-            <Box childGap="2xs" margin="0 0 0 xs">
-              {label && <div>{label}</div>}
-              {helpText && (
-                <Box as="p" display="block" fontSize="sm" fontWeight="regular" color="grey">
-                  {helpText}
-                </Box>
-              )}
-            </Box>
-          )}
-        </FormLabel>
+      <Box
+        direction="row"
+        childGap="xs"
+        alignItems={helpText ? 'flex-start' : 'center'}
+        className={wrapperClasses}
+      >
+        <input {...inputProps} />
+        <span aria-hidden="true" className={trackClasses}>
+          <span className={thumbClasses} />
+        </span>
+        {label && !hideLabel && <FormLabel {...labelProps}>{label}</FormLabel>}
       </Box>
       {error && error !== true && <InputValidationMessage>{error}</InputValidationMessage>}
     </Box>


### PR DESCRIPTION
# Github Issue or Trello Card

Refactors the Toggle component so that FormLabel usage is independent of the actual toggle markup. This gives us more control and standardization of for helpText, error, and isRequired states. 

# What type of change is this?
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Updating documentation.
- [ ] Updating deployment/build pipeline.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

# UI Checklist
- [ ] I have conducted visual UAT on my changes/features.
- [ ] My solution works well on desktop, tablet, and mobile browsers.