### PR TITLE
fix(TextLink): allow font size utility classes to be applied

### DIFF
--- a/src/components/TextLink/TextLink.module.scss
+++ b/src/components/TextLink/TextLink.module.scss
@@ -1,6 +1,4 @@
 .text-link {
-  font-size: inherit;
-
   &.primary {
     text-decoration-color: var(--text-link-font-color-primary);
     color: var(--text-link-font-color-primary);


### PR DESCRIPTION
# Github Issue or Trello Card

Allows css utility font size classes to get applied rather than always inheriting from the parent, for example:

`<TextLink className="font-size-sm font-size-md-tablet" />`


# What type of change is this?
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Updating documentation.
- [ ] Updating deployment/build pipeline.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

# UI Checklist
- [ ] I have conducted visual UAT on my changes/features.
- [ ] My solution works well on desktop, tablet, and mobile browsers.