### PR TITLE
Set background color to transparent when textarea is disabled

### DIFF
--- a/src/components/TextareaInput/TextareaInput.module.scss
+++ b/src/components/TextareaInput/TextareaInput.module.scss
@@ -10,6 +10,7 @@
 .textarea-input-wrapper {
   &.disabled {
     @extend %disabled-base;
+    background-color: transparent;
   }
 
   > textarea {

--- a/src/components/TextareaInput/TextareaInput.module.scss
+++ b/src/components/TextareaInput/TextareaInput.module.scss
@@ -1,18 +1,4 @@
-%disabled-base {
-  background-color: var(--form-control-disabled-background-color);
-  color: var(--form-control-disabled-font-color);
-
-  &:hover {
-    cursor: not-allowed;
-  }
-}
-
 .textarea-input-wrapper {
-  &.disabled {
-    @extend %disabled-base;
-    background-color: transparent;
-  }
-
   > textarea {
     transition-duration: 300ms;
     transition-property: border, background-color;
@@ -39,7 +25,12 @@
     }
 
     &:disabled {
-      @extend %disabled-base;
+      background-color: var(--form-control-disabled-background-color);
+      color: var(--form-control-disabled-font-color);
+    
+      &:hover {
+        cursor: not-allowed;
+      }
     }
   }
 

--- a/src/components/TextareaInput/TextareaInput.module.scss
+++ b/src/components/TextareaInput/TextareaInput.module.scss
@@ -1,3 +1,12 @@
+%disabled-base {
+  background-color: var(--form-control-disabled-background-color);
+  color: var(--form-control-disabled-font-color);
+
+  &:hover {
+    cursor: not-allowed;
+  }
+}
+
 .textarea-input-wrapper {
   > textarea {
     transition-duration: 300ms;
@@ -25,12 +34,7 @@
     }
 
     &:disabled {
-      background-color: var(--form-control-disabled-background-color);
-      color: var(--form-control-disabled-font-color);
-    
-      &:hover {
-        cursor: not-allowed;
-      }
+      @extend %disabled-base;
     }
   }
 


### PR DESCRIPTION
# Github Issue or Trello Card
This PR addresses this issue: [Remove unnecessary background from TextareaInput when disabled](https://trello.com/c/fz1VjEzl/1101-remove-unnecessary-background-from-textareainput-when-disabled)

This PR adjusts the background color on disabled textarea inputs to prevent this UI issue in dark mode:
![image](https://user-images.githubusercontent.com/16456162/128036836-dd9ff9e6-7b84-4f12-b50c-23b1aa730185.png)


# What type of change is this?
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

# UI Checklist
- [x] I have conducted visual UAT on my changes/features.
- [x] My solution works well on desktop, tablet, and mobile browsers.