### PR TITLE
fix(SelectInputNative): adding extra padding to prevent arrow overlap

### DIFF
--- a/src/components/SelectInputNative/SelectInputNative.module.scss
+++ b/src/components/SelectInputNative/SelectInputNative.module.scss
@@ -75,7 +75,8 @@
 
     > select {
       border-radius: var(--form-control-size-lg-border-radius);
-      padding: 0 var(--form-control-size-sm-padding);
+      padding-left: var(--form-control-size-sm-padding);
+      padding-right: var(--size-spacing-2xl);
       padding-top: calc(var(--form-control-size-sm-padding) - 1px);
       padding-bottom: calc(var(--form-control-size-sm-padding) - 1px);
     }
@@ -102,7 +103,8 @@
 
     > select {
       border-radius: var(--form-control-size-lg-border-radius);
-      padding: 0 var(--form-control-size-md-padding);
+      padding-left: var(--form-control-size-md-padding);
+      padding-right: var(--size-spacing-3xl);
       padding-top: calc(var(--form-control-size-md-padding) - 1px);
       padding-bottom: calc(var(--form-control-size-md-padding) - 1px);
     }
@@ -129,7 +131,8 @@
 
     > select {
       border-radius: var(--form-control-size-lg-border-radius);
-      padding: 0 var(--form-control-size-lg-padding);
+      padding-left: var(--form-control-size-lg-padding);
+      padding-right: var(--size-spacing-3xl);
       padding-top: calc(var(--form-control-size-lg-padding) - 1px);
       padding-bottom: calc(var(--form-control-size-lg-padding) - 1px);
     }


### PR DESCRIPTION
# Github Issue or Trello Card
This PR addresses this issue: https://github.com/palmetto/palmetto-components/issues/527

For this case I just added extra padding on the right hand side. This prevents the text clashing with the caret, and maintains the native select interactivity for the entire element.

# What type of change is this?
Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Updating documentation.
- [ ] Updating deployment/build pipeline.

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes

# UI Checklist
- [X] I have conducted visual UAT on my changes/features.
- [X] My solution works well on desktop, tablet, and mobile browsers.