### PR TITLE
fix(Details): only prevent default when toggling open panel

### DIFF
--- a/src/components/Details/DetailsSummary.tsx
+++ b/src/components/Details/DetailsSummary.tsx
@@ -30,11 +30,14 @@ export const DetailsSummary: React.FC<DetailsSummaryProps> = ({
   };
 
   const handleKeyDown = (event: KeyboardEvent<HTMLElement>) => {
+    if ([ENTER, SPACE].indexOf(event.keyCode) !== -1) {
+      // Needed to avoid default `details` behavior on a click event and keep this as controlled component.
+      event.preventDefault();
+    }
+
     if (!onToggle && !restProps?.onKeyDown) return;
 
     if (onToggle && [ENTER, SPACE].indexOf(event.keyCode) !== -1) {
-      // Needed to avoid default `details` behavior on a click event and keep this as controlled component.
-      event.preventDefault();
       onToggle(event);
     }
 

--- a/src/components/Details/DetailsSummary.tsx
+++ b/src/components/Details/DetailsSummary.tsx
@@ -30,12 +30,11 @@ export const DetailsSummary: React.FC<DetailsSummaryProps> = ({
   };
 
   const handleKeyDown = (event: KeyboardEvent<HTMLElement>) => {
-    // Needed to avoid default `details` behavior on a click event and keep this as controlled component.
-    event.preventDefault();
-
     if (!onToggle && !restProps?.onKeyDown) return;
 
     if (onToggle && [ENTER, SPACE].indexOf(event.keyCode) !== -1) {
+      // Needed to avoid default `details` behavior on a click event and keep this as controlled component.
+      event.preventDefault();
       onToggle(event);
     }
 


### PR DESCRIPTION
# Github Issue or Trello Card
This PR addresses this issue: https://github.com/palmetto/palmetto-components/issues/541

The issue is present because we prevent default on the keyDown even in the summary element. This is done because if we don't, then the details will expand on their own (part of HTML spec) and we will have mismatching state, which means we no longer have a controlled component. The solution is to only prevent default on the event when the user is actually expanding with the ENTER or SPACE keys. All other keydown events will proceed as usual, which fixes tabbing.

# What type of change is this?
Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Updating documentation.
- [ ] Updating deployment/build pipeline.

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes

# UI Checklist
- [X] I have conducted visual UAT on my changes/features.
- [X] My solution works well on desktop, tablet, and mobile browsers.