### PR TITLE
Add target attribute if one is passed as a prop

### DIFF
--- a/src/components/Button/Button.test.jsx
+++ b/src/components/Button/Button.test.jsx
@@ -181,40 +181,6 @@ describe('Button', () => {
         expect(buttonElement).toBeInTheDocument();
       });
 
-      test('it renders an anchor tag if as prop `a` is passed', () => {
-        render(
-          <Button href="http://palmetto.com" as="a">
-            hey there
-          </Button>,
-        );
-        const buttonElement = screen.getByRole('link');
-
-        expect(buttonElement).toBeInTheDocument();
-      });
-
-      test('it does not have a button type attribute if as prop `a` is passed', () => {
-        render(
-          <Button href="http://palmetto.com" as="a">
-            hey there
-          </Button>,
-        );
-        const buttonElement = screen.getByRole('link');
-
-        expect(buttonElement.getAttribute('type')).toBe(null);
-      });
-
-      test('it renders a target attribute if one is passed', () => {
-        render(
-          <Button href="http://palmetto.com" as="a" target="_blank">
-            hey there
-          </Button>,
-        );
-        const buttonElement = screen.getByRole('link');
-
-        expect(buttonElement).toBeInTheDocument();
-        expect(buttonElement).toHaveAttribute('target');
-      });
-
       test('it does not have a disabled attribute', () => {
         render(<Button>Not Disabled Button</Button>);
 
@@ -333,6 +299,66 @@ describe('Button', () => {
         render(<Button isOutlined>primary</Button>);
 
         expect(screen.getByText('primary').closest('button')).toHaveClass('outline');
+      });
+    });
+
+    describe('Anchor', () => {
+      test('it renders an anchor tag if as prop `a` is passed', () => {
+        render(
+          <Button href="http://palmetto.com" as="a">
+            hey there
+          </Button>,
+        );
+        const buttonElement = screen.getByRole('link');
+
+        expect(buttonElement).toBeInTheDocument();
+      });
+
+      test('it does not have a button type attribute if as prop `a` is passed', () => {
+        render(
+          <Button href="http://palmetto.com" as="a">
+            hey there
+          </Button>,
+        );
+        const buttonElement = screen.getByRole('link');
+
+        expect(buttonElement.getAttribute('type')).toBe(null);
+      });
+
+      test('it renders a target attribute if one is passed, the element is an anchor, and there is a href', () => {
+        render(
+          <Button href="http://palmetto.com" as="a" target="_blank">
+            hey there
+          </Button>,
+        );
+        const buttonElement = screen.getByRole('link');
+
+        expect(buttonElement).toBeInTheDocument();
+        expect(buttonElement).toHaveAttribute('target');
+      });
+
+      test('it does not render a target attribute if the element is not an anchor', () => {
+        render(
+          <Button href="http://palmetto.com" target="_blank">
+            hey there
+          </Button>,
+        );
+        const buttonElement = screen.getByRole('button');
+
+        expect(buttonElement).toBeInTheDocument();
+        expect(buttonElement).not.toHaveAttribute('target');
+      });
+
+      test('it does not render a target attribute if the element does not have an href', () => {
+        render(
+          <Button as="a" target="_blank">
+            hey there
+          </Button>,
+        );
+        const buttonElement = screen.getByRole('link');
+
+        expect(buttonElement).toBeInTheDocument();
+        expect(buttonElement).not.toHaveAttribute('target');
       });
     });
   });

--- a/src/components/Button/Button.test.jsx
+++ b/src/components/Button/Button.test.jsx
@@ -355,7 +355,7 @@ describe('Button', () => {
             hey there
           </Button>,
         );
-        const buttonElement = screen.getByRole('link');
+        const buttonElement = screen.getByText('hey there');
 
         expect(buttonElement).toBeInTheDocument();
         expect(buttonElement).not.toHaveAttribute('target');

--- a/src/components/Button/Button.test.jsx
+++ b/src/components/Button/Button.test.jsx
@@ -57,31 +57,27 @@ describe('Button', () => {
   });
 
   describe('Sizes', () => {
-    BUTTON_SIZES.map(size =>
-      describe(`${BUTTON_SIZES}`, () => {
-        test(`it has a ${size} class applied to it`, () => {
-          render(<Button size={size}>{`${size} Button`}</Button>);
+    BUTTON_SIZES.map(size => describe(`${BUTTON_SIZES}`, () => {
+      test(`it has a ${size} class applied to it`, () => {
+        render(<Button size={size}>{`${size} Button`}</Button>);
 
-          const btn = screen.getByText(`${size} Button`).closest('button');
+        const btn = screen.getByText(`${size} Button`).closest('button');
 
-          expect(btn.getAttribute('class')).toContain(size);
-        });
-      }),
-    );
+        expect(btn.getAttribute('class')).toContain(size);
+      });
+    }));
   });
 
   describe('Variants', () => {
-    BUTTON_VARIANTS.map(variant =>
-      describe(`${BUTTON_VARIANTS}`, () => {
-        test(`it has a ${variant} class applied to it`, () => {
-          render(<Button variant={variant}>{`${variant} Button`}</Button>);
+    BUTTON_VARIANTS.map(variant => describe(`${BUTTON_VARIANTS}`, () => {
+      test(`it has a ${variant} class applied to it`, () => {
+        render(<Button variant={variant}>{`${variant} Button`}</Button>);
 
-          const btn = screen.getByText(`${variant} Button`).closest('button');
+        const btn = screen.getByText(`${variant} Button`).closest('button');
 
-          expect(btn.getAttribute('class')).toContain(variant);
-        });
-      }),
-    );
+        expect(btn.getAttribute('class')).toContain(variant);
+      });
+    }));
   });
 
   describe('Callback Handling', () => {
@@ -207,6 +203,18 @@ describe('Button', () => {
         expect(buttonElement.getAttribute('type')).toBe(null);
       });
 
+      test('it renders a target attribute if one is passed', () => {
+        render(
+          <Button href="http://palmetto.com" as="a" target="_blank">
+            hey there
+          </Button>,
+        );
+        const buttonElement = screen.getByRole('link');
+
+        expect(buttonElement).toBeInTheDocument();
+        expect(buttonElement).toHaveAttribute('target');
+      });
+
       test('it does not have a disabled attribute', () => {
         render(<Button>Not Disabled Button</Button>);
 
@@ -214,12 +222,12 @@ describe('Button', () => {
       });
 
       test('it renders an empty button when no children are passed', () => {
-        render(<Button></Button>);
+        render(<Button />);
         const buttonElement = screen.getByRole('button');
 
         expect(buttonElement).toBeInTheDocument();
         expect(buttonElement.innerText).toBe(undefined);
-      });      
+      });
     });
 
     describe('Full Width', () => {
@@ -329,12 +337,11 @@ describe('Button', () => {
     });
   });
 
-
   describe('React Router', () => {
     it('fires navigate callback when included', () => {
       const mockedNavigate = jest.fn(() => {});
       render(<Button as="a" navigate={mockedNavigate} href="/">react router link</Button>);
-      
+
       fireEvent.click(screen.getByText('react router link').closest('a'));
 
       expect(mockedNavigate).toBeCalledTimes(1);
@@ -343,7 +350,7 @@ describe('Button', () => {
     it('does not fire navigate callback if target is _blank', () => {
       const mockedNavigate = jest.fn(() => {});
       render(<Button as="a" navigate={mockedNavigate} href="/" target="_blank">react router link</Button>);
-      
+
       fireEvent.click(screen.getByText('react router link').closest('a'));
 
       expect(mockedNavigate).toBeCalledTimes(0);

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -215,7 +215,7 @@ export const Button: FC<ButtonProps> = forwardRef(
         (event: MouseEvent<HTMLAnchorElement | HTMLButtonElement>) => handleClick(event, onClick, target, navigate),
       onFocus: handleFocus,
       ref,
-      type: href ? null : type,
+      type: (href || as === 'a') ? null : type,
       tabIndex,
       ...restProps,
     });

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -84,7 +84,7 @@ export interface ButtonProps {
    */
   tabIndex?: number;
   /**
-   * Usefull when using button as an anchor tag.
+   * Useful when using button as an anchor tag.
    */
   target?: AnchorHTMLAttributes<HTMLAnchorElement>['target'];
   /**
@@ -209,6 +209,7 @@ export const Button: FC<ButtonProps> = forwardRef(
       className: buttonClasses,
       children: buttonContent,
       disabled,
+      target,
       onBlur: handleBlur,
       onClick:
         (event: MouseEvent<HTMLAnchorElement | HTMLButtonElement>) => handleClick(event, onClick, target, navigate),

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -209,7 +209,7 @@ export const Button: FC<ButtonProps> = forwardRef(
       className: buttonClasses,
       children: buttonContent,
       disabled,
-      target,
+      target: (as === 'a' && href) ? target : null,
       onBlur: handleBlur,
       onClick:
         (event: MouseEvent<HTMLAnchorElement | HTMLButtonElement>) => handleClick(event, onClick, target, navigate),


### PR DESCRIPTION
# Github Issue or Trello Card
This PR addresses this issue: 
For Button, a target attribute wasn't being added to the button tag when one was passed as a prop; this prevented being able to use `target="_blank"`, for example. This PR fixes this, and adds a test to validate the change.

# What type of change is this?
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Updating documentation.
- [ ] Updating deployment/build pipeline.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

# UI Checklist
- [x] I have conducted visual UAT on my changes/features.
- [x] My solution works well on desktop, tablet, and mobile browsers.