### PR TITLE
fix: disabled text input text color

### DIFF
--- a/src/components/TextInput/TextInput.module.scss
+++ b/src/components/TextInput/TextInput.module.scss
@@ -1,6 +1,9 @@
 %disabled-base {
   background-color: var(--form-control-disabled-background-color);
   color: var(--form-control-disabled-font-color);
+  /* https://stackoverflow.com/questions/262158/disabled-input-text-color-on-ios */
+  -webkit-text-fill-color: var(--form-control-disabled-font-color);
+  opacity: 1;
 
   &:hover {
     cursor: not-allowed;


### PR DESCRIPTION
# Github Issue or Trello Card
This PR addresses this issue: https://palmetto.zendesk.com/agent/tickets/318709

We never caught this b/c chromatic doesn't run on safari at the moment.

safari:
<img width="1033" alt="Screen Shot 2021-08-11 at 4 58 55 PM" src="https://user-images.githubusercontent.com/1447339/129118536-c361b6bc-66cd-4144-ad6b-2841c00b2b0d.png">

chrome:
<img width="839" alt="Screen Shot 2021-08-11 at 5 00 05 PM" src="https://user-images.githubusercontent.com/1447339/129118578-bf5c7f6d-f938-475a-b8c3-76035b8c374f.png">


# What type of change is this?
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Updating documentation.
- [ ] Updating deployment/build pipeline.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

# UI Checklist
- [ ] I have conducted visual UAT on my changes/features.
- [ ] My solution works well on desktop, tablet, and mobile browsers.