### PR TITLE
fix(DateInput): Date picker close on selection

### DIFF
--- a/src/components/DateInput/DateInput.test.tsx
+++ b/src/components/DateInput/DateInput.test.tsx
@@ -100,10 +100,10 @@ describe('DateInput', () => {
       const popoverContainer = screen.getByRole('dialog');
       await waitFor(() => expect(popoverContainer).toHaveAttribute('data-popper-placement', 'bottom'));
       const dateButton = screen.getByText('14');
-      await waitFor(() => { fireEvent.click(dateButton) });
+      await waitFor(() => { fireEvent.click(dateButton); });
 
       const popover = screen.queryByRole('dialog');
-      await waitFor(() => { expect(popover).toBeNull() });
+      await waitFor(() => { expect(popover).toBeNull(); });
     });
 
     it('keeps popover open while user is selecting a Date range', async () => {
@@ -131,7 +131,7 @@ describe('DateInput', () => {
       const popoverContainer = screen.getByRole('dialog');
       await waitFor(() => expect(popoverContainer).toHaveAttribute('data-popper-placement', 'bottom'));
       const dateButton = screen.getByText('14');
-      await waitFor(() => { fireEvent.click(dateButton) });
+      await waitFor(() => { fireEvent.click(dateButton); });
 
       const popover = screen.queryByRole('dialog');
       await waitFor(() => { expect(popover).toHaveAttribute('data-popper-placement', 'bottom'); });

--- a/src/components/DateInput/DateInput.test.tsx
+++ b/src/components/DateInput/DateInput.test.tsx
@@ -75,6 +75,67 @@ describe('DateInput', () => {
       const popover = screen.queryByRole('dialog');
       expect(popover).toBeNull();
     });
+
+    it('closes popover when user selects a value NOT in a range', async () => {
+      const date = new Date(1995, 11, 14);
+
+      render(
+        <DateInput
+          dateFormat="yyyy/MM/dd"
+          textInputProps={{
+            id: 'myInput',
+            label: 'Select Date',
+          }}
+          datePickerProps={{
+            openToDate: date,
+            selected: null,
+            onChange: () => null,
+          }}
+        />,
+      );
+
+      const input = screen.getByLabelText('Select Date');
+      fireEvent.click(input);
+
+      const popoverContainer = screen.getByRole('dialog');
+      await waitFor(() => expect(popoverContainer).toHaveAttribute('data-popper-placement', 'bottom'));
+      const dateButton = screen.getByText('14');
+      await waitFor(() => { fireEvent.click(dateButton) });
+
+      const popover = screen.queryByRole('dialog');
+      await waitFor(() => { expect(popover).toBeNull() });
+    });
+
+    it('keeps popover open while user is selecting a Date range', async () => {
+      const date = new Date(1995, 11, 14);
+
+      render(
+        <DateInput
+          dateFormat="yyyy/MM/dd"
+          textInputProps={{
+            id: 'myInput',
+            label: 'Select Date',
+          }}
+          datePickerProps={{
+            openToDate: date,
+            selected: null,
+            onChange: () => null,
+            selectsRange: true,
+          }}
+        />,
+      );
+
+      const input = screen.getByLabelText('Select Date');
+      fireEvent.click(input);
+
+      const popoverContainer = screen.getByRole('dialog');
+      await waitFor(() => expect(popoverContainer).toHaveAttribute('data-popper-placement', 'bottom'));
+      const dateButton = screen.getByText('14');
+      await waitFor(() => { fireEvent.click(dateButton) });
+
+      const popover = screen.queryByRole('dialog');
+      await waitFor(() => { expect(popover).toHaveAttribute('data-popper-placement', 'bottom'); });
+    });
   });
 
   describe('Date Formatting', () => {

--- a/src/components/DateInput/DateInput.tsx
+++ b/src/components/DateInput/DateInput.tsx
@@ -11,14 +11,44 @@ import { TextInput, TextInputProps } from '../TextInput/TextInput';
 import { Popover, PopoverProps } from '../Popover/Popover';
 
 export interface DateInputProps {
+  /**
+   * Props object for DatePicker component.
+   */
   datePickerProps: DatePickerProps;
+  /**
+   * Props object for TextInput component.
+   */
   textInputProps: Omit<TextInputProps, 'onChange'>;
+  /**
+   * Format for final date to be displayed.
+   * Relies on date-fns/format --> https://date-fns.org/v1.9.0/docs/format
+   */
   dateFormat?: string;
+  /**
+   * Additional settings for formatting date.
+   */
   dateOptions?: {
+    /**
+     * The user's locale.
+     */
     locale?: globalThis.Locale | undefined;
+    /**
+     * Start of week.
+     */
     weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6 | undefined;
+    /**
+     * Should determine which week is week 1 of a new year.
+     */
     firstWeekContainsDate?: number | undefined;
+    /** 
+     * Whether to accept unicode tokens in format.
+     * See here --> https://github.com/date-fns/date-fns/blob/master/docs/unicodeTokens.md
+     */
     useAdditionalWeekYearTokens?: boolean | undefined;
+    /** 
+     * Whether to accept unicode tokens in format.
+     * See here --> https://github.com/date-fns/date-fns/blob/master/docs/unicodeTokens.md
+     */
     useAdditionalDayOfYearTokens?: boolean | undefined;
   };
   popoverProps?: Omit<PopoverProps, 'children' | 'content' | 'isOpen'>;
@@ -116,10 +146,19 @@ export const DateInput: FC<DateInputProps> = ({
     }
   }, [isPopoverOpen]);
 
+  const handleDatePickerChange = (date: Date | [Date, Date] | null, event: React.SyntheticEvent<any, Event> | undefined) => {
+
+    mergedDatePickerProps.onChange(date, event);
+
+    if (!mergedDatePickerProps.selectsRange && date) {
+      setPopoverOpen(false);
+    }
+  }
+
   const renderDatePicker = () => (
     <DatePicker
       {...mergedDatePickerProps}
-      onChange={mergedDatePickerProps.onChange}
+      onChange={handleDatePickerChange}
       selected={mergedDatePickerProps.selected}
       selectsRange={mergedDatePickerProps.selectsRange}
     />

--- a/src/components/DateInput/DateInput.tsx
+++ b/src/components/DateInput/DateInput.tsx
@@ -40,12 +40,12 @@ export interface DateInputProps {
      * Should determine which week is week 1 of a new year.
      */
     firstWeekContainsDate?: number | undefined;
-    /** 
+    /**
      * Whether to accept unicode tokens in format.
      * See here --> https://github.com/date-fns/date-fns/blob/master/docs/unicodeTokens.md
      */
     useAdditionalWeekYearTokens?: boolean | undefined;
-    /** 
+    /**
      * Whether to accept unicode tokens in format.
      * See here --> https://github.com/date-fns/date-fns/blob/master/docs/unicodeTokens.md
      */
@@ -146,14 +146,14 @@ export const DateInput: FC<DateInputProps> = ({
     }
   }, [isPopoverOpen]);
 
-  const handleDatePickerChange = (date: Date | [Date, Date] | null, event: React.SyntheticEvent<any, Event> | undefined) => {
-
+  const handleDatePickerChange = (
+    date: Date | [Date, Date] | null,
+    event: React.SyntheticEvent<any, Event> | undefined, // eslint-disable-line @typescript-eslint/no-explicit-any
+  ) => {
     mergedDatePickerProps.onChange(date, event);
 
-    if (!mergedDatePickerProps.selectsRange && date) {
-      setPopoverOpen(false);
-    }
-  }
+    if (!mergedDatePickerProps.selectsRange && date) setPopoverOpen(false);
+  };
 
   const renderDatePicker = () => (
     <DatePicker


### PR DESCRIPTION
# Github Issue or Trello Card
This PR addresses this issue: https://github.com/palmetto/palmetto-components/issues/496

`DateInput` component is now set to close the popover upon date selection by the user, EXCEPT in cases where `selectsRange` is true, since the user is expected to select multiple dates before exiting the popover.

# What type of change is this?
Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Updating documentation.
- [ ] Updating deployment/build pipeline.

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes

# UI Checklist
- [X] I have conducted visual UAT on my changes/features.
- [X] My solution works well on desktop, tablet, and mobile browsers.