### PR TITLE
fix(Modal): add flag to avoid reach CSS warning

### DIFF
--- a/src/components/Modal/Modal.module.scss
+++ b/src/components/Modal/Modal.module.scss
@@ -1,6 +1,7 @@
 @import '~@palmetto/palmetto-design-tokens/build/scss/variables-size';
 
-
+/* This line prevents @reach/dialog from throwing a warning due to not importing their CSS. */
+:root { --reach-dialog: 1; }
 
 .modal-close {
   border: none;


### PR DESCRIPTION
# Github Issue or Trello Card
This PR addresses this issue: https://trello.com/c/8MT98ssJ/719-consumers-of-palmetto-components-are-seeing-a-console-warning-to-include-the-reach-dialog-styles

Currently, users are getting a warning for not including @reach/dialog styles, while it is only present in DEV/test environments, it is confusing nonetheless. We don't use these styles so we don't want to import them, but B=by setting --reach-dialog CSS variable to `1`, it lets the library know that styles are present (we are tricking it basically).

# What type of change is this?
Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Updating documentation.
- [ ] Updating deployment/build pipeline.

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes

# UI Checklist
- [X] I have conducted visual UAT on my changes/features.
- [X] My solution works well on desktop, tablet, and mobile browsers.