### PR TITLE
add size + responsive size to TextareaInput

### DIFF
--- a/src/components/TextareaInput/TextareaInput.Overview.stories.mdx
+++ b/src/components/TextareaInput/TextareaInput.Overview.stories.mdx
@@ -118,6 +118,53 @@ The `resize` prop accepts `horizontal`, `vertical`, `both` or `none` to control 
   </Story>
 </Canvas>
 
+## Sizes
+
+Set the `size` of the input to `sm`, `md` or `lg`. The `size` prop is also a `ResponsiveProp`, so it can be sized differently at each [breakpoint](?path=/story/design-tokens-breakpoints--page) by passing an object.
+
+<Canvas>
+  <Story name="Sizes">
+    {() => {
+      const [valueSm, setValueSm] = useState('');
+      const [valueMd, setValueMd] = useState('');
+      const [valueLg, setValueLg] = useState('');
+      const [valueResponsive, setValueResponsive] = useState('');
+      return (
+        <Box childGap="md">
+          <TextareaInput
+            id="Small"
+            value={valueSm}
+            label="Small"
+            onChange={event => setValueSm(event.target.value)}
+            size="sm"
+          />
+          <TextareaInput
+            id="Medium"
+            value={valueMd}
+            label="Medium"
+            onChange={event => setValueMd(event.target.value)}
+            size="md"
+          />
+          <TextareaInput
+            id="Large"
+            value={valueLg}
+            label="Large"
+            onChange={event => setValueLg(event.target.value)}
+            size="lg"
+          />
+          <TextareaInput
+            id="Responsive"
+            value={valueResponsive}
+            label="Responsive"
+            onChange={event => setValueResponsive(event.target.value)}
+            size={{ base: 'sm', tablet: 'md', desktop: 'lg', hd: 'sm' }}
+          />
+        </Box>
+      );
+    }}
+  </Story>
+</Canvas>
+
 ## Placeholder
 
 Use the `placeholder` prop to add a custom placeholder.

--- a/src/components/TextareaInput/TextareaInput.VisualTests.stories.tsx
+++ b/src/components/TextareaInput/TextareaInput.VisualTests.stories.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { Meta, Story } from '@storybook/react/types-6-0';
+import { TextareaInput, TextareaInputProps } from './TextareaInput';
+import { RESPONSIVE_STORY } from '../../docs/constants';
+
+export default {
+  title: 'Components/TextareaInput/Visual Regression Tests',
+  component: TextareaInput,
+} as Meta;
+
+const Template: Story<TextareaInputProps> = args => (
+  <TextareaInput
+    {...args}
+    onChange={() => {}} // eslint-disable-line
+  />
+);
+
+export const ResponsiveSize = Template.bind({});
+ResponsiveSize.args = {
+  size: {
+    base: 'sm',
+    tablet: 'md',
+    desktop: 'lg',
+    hd: 'sm',
+  },
+  value: 'responsive',
+};
+ResponsiveSize.parameters = RESPONSIVE_STORY;

--- a/src/components/TextareaInput/TextareaInput.module.scss
+++ b/src/components/TextareaInput/TextareaInput.module.scss
@@ -13,14 +13,11 @@
     transition-property: border, background-color;
     transition-timing-function: cubic-bezier(0.2, 0.8, 0.4, 1);
     border: 1px solid var(--form-control-border-color);
-    border-radius: var(--form-control-size-md-border-radius);
     box-shadow: 0 3px 0 rgba(0, 0, 0, 0.05);
     background-color: var(--form-control-background-color);
-    padding: var(--form-control-size-md-padding);
     width: 100%;
     line-height: var(--form-control-line-height);
     color: var(--form-control-font-color);
-    font-size: var(--form-control-size-md-font-size);
 
     &::placeholder {
       /* Override lower placeholder opacity in Firefox */

--- a/src/components/TextareaInput/TextareaInput.tsx
+++ b/src/components/TextareaInput/TextareaInput.tsx
@@ -2,12 +2,15 @@ import React, {
   FC, ChangeEvent, FocusEvent, ReactNode,
 } from 'react';
 import classNames from 'classnames';
+import { ResponsiveProp } from '../../types';
 import { Box, BoxProps } from '../Box/Box';
 import { FormLabel } from '../FormLabel/FormLabel';
 import { InputValidationMessage } from '../InputValidationMessage/InputValidationMessage';
 import getAutoCompleteValue from '../../lib/getAutoCompleteValue';
+import { computedResponsiveSize } from './TextareaInputSizeUtilities'; // eslint-disable-line import/no-cycle
 import styles from './TextareaInput.module.scss';
 
+export type TextareaInputSize = 'sm' | 'md' | 'lg';
 export interface TextareaInputProps extends Omit<BoxProps, 'as' | 'width'> {
   /**
    * The input's id attribute. Used to programmatically tie the input with its label.
@@ -88,6 +91,10 @@ export interface TextareaInputProps extends Omit<BoxProps, 'as' | 'width'> {
    */
   rows?: number;
   /**
+   * The size of the text input.
+   */
+  size?: TextareaInputSize | ResponsiveProp<TextareaInputSize>;
+  /**
    * Additional props to be spread to rendered element
    */
   [x: string]: any; // eslint-disable-line
@@ -113,12 +120,16 @@ export const TextareaInput: FC<TextareaInputProps> = ({
   placeholder = '',
   resize = 'vertical',
   rows = 3,
+  size = 'md',
   ...restProps
 }) => {
-  const inputWrapperClasses = classNames(styles['textarea-input-wrapper'], {
-    [styles.error]: error,
-    [styles.disabled]: isDisabled,
-  });
+  const inputWrapperClasses = classNames(
+    styles['textarea-input-wrapper'],
+    {
+      [styles.error]: error,
+      [styles.disabled]: isDisabled,
+    },
+  );
 
   const inputProps = {
     'aria-required': isRequired,
@@ -135,6 +146,9 @@ export const TextareaInput: FC<TextareaInputProps> = ({
     onBlur,
     onChange,
     onFocus,
+    padding: computedResponsiveSize(size, 'padding'),
+    fontSize: computedResponsiveSize(size, 'fontSize'),
+    radius: computedResponsiveSize(size, 'radius'),
     placeholder,
     rows,
     value,
@@ -151,9 +165,12 @@ export const TextareaInput: FC<TextareaInputProps> = ({
   return (
     <Box width="100%" className={className} {...restProps}>
       {label && !hideLabel && <FormLabel {...labelProps}>{label}</FormLabel>}
-      <div className={inputWrapperClasses}>
-        <textarea {...inputProps} />
-      </div>
+      <Box
+        display="block"
+        className={inputWrapperClasses}
+      >
+        <Box as="textarea" {...inputProps} />
+      </Box>
       {error && error !== true && <InputValidationMessage>{error}</InputValidationMessage>}
     </Box>
   );

--- a/src/components/TextareaInput/TextareaInputSizeUtilities.test.ts
+++ b/src/components/TextareaInput/TextareaInputSizeUtilities.test.ts
@@ -1,0 +1,54 @@
+import {
+  computedResponsiveSize,
+  borderRadiusSizeMap,
+  paddingSizeMap,
+  fontSizeMap,
+} from './TextareaInputSizeUtilities';
+import { BreakpointSizeWithBase } from '../../types';
+import { TextareaInputSize } from './TextareaInput';
+
+describe('TextareaInputSizeUtilities', () => {
+  test('It returns correct map values based on established constants for single value sizes', () => {
+    Object.entries(borderRadiusSizeMap).forEach(([key, value]) => {
+      expect(computedResponsiveSize(key as TextareaInputSize, 'radius')).toBe(value);
+    });
+
+    Object.entries(paddingSizeMap).forEach(([key, value]) => {
+      expect(computedResponsiveSize(key as TextareaInputSize, 'padding')).toBe(value);
+    });
+
+    Object.entries(fontSizeMap).forEach(([key, value]) => {
+      expect(computedResponsiveSize(key as TextareaInputSize, 'fontSize')).toBe(value);
+    });
+  });
+
+  test('It returns correct mapped responsive object props for each property', () => {
+    const size: { [key in BreakpointSizeWithBase]: TextareaInputSize; } = {
+      base: 'sm',
+      tablet: 'md',
+      desktop: 'lg',
+      hd: 'md',
+    };
+
+    expect(computedResponsiveSize(size, 'radius')).toEqual({
+      base: borderRadiusSizeMap[size.base],
+      tablet: borderRadiusSizeMap[size.tablet],
+      desktop: borderRadiusSizeMap[size.desktop],
+      hd: borderRadiusSizeMap[size.hd],
+    });
+
+    expect(computedResponsiveSize(size, 'padding')).toEqual({
+      base: paddingSizeMap[size.base],
+      tablet: paddingSizeMap[size.tablet],
+      desktop: paddingSizeMap[size.desktop],
+      hd: paddingSizeMap[size.hd],
+    });
+
+    expect(computedResponsiveSize(size, 'fontSize')).toEqual({
+      base: fontSizeMap[size.base],
+      tablet: fontSizeMap[size.tablet],
+      desktop: fontSizeMap[size.desktop],
+      hd: fontSizeMap[size.hd],
+    });
+  });
+});

--- a/src/components/TextareaInput/TextareaInputSizeUtilities.ts
+++ b/src/components/TextareaInput/TextareaInputSizeUtilities.ts
@@ -1,0 +1,46 @@
+import { BorderRadiusSize, FontSize } from '../../types';
+import { BoxProps } from '../Box/Box';
+import { TextareaInputProps, TextareaInputSize } from './TextareaInput'; // eslint-disable-line import/no-cycle
+
+export const borderRadiusSizeMap: { [key in TextareaInputSize]: BorderRadiusSize; } = {
+  sm: 'sm',
+  md: 'md',
+  lg: 'md',
+};
+
+export const paddingSizeMap: { [key in TextareaInputSize]: BoxProps['padding']; } = {
+  sm: 'xs',
+  md: 'sm',
+  lg: 'md',
+};
+
+export const fontSizeMap: { [key in TextareaInputSize]: FontSize; } = {
+  sm: 'sm',
+  md: 'md',
+  lg: 'lg',
+};
+
+export const inputSizeMaps = {
+  radius: borderRadiusSizeMap,
+  fontSize: fontSizeMap,
+  padding: paddingSizeMap,
+};
+
+/**
+ * Convert TextareaInputSize (sm | md | lg) to their corresponding values on a per prop basis.
+ *
+ * @param size size prop passed down to component
+ * @param prop Property map to use to map each breakpoint value.
+ * @returns A mapping of responsive prop objects to their corresponding values per prop
+ */
+export const computedResponsiveSize = ( // eslint-disable-line @typescript-eslint/explicit-module-boundary-types
+  size: TextareaInputProps['size'],
+  prop: 'padding' | 'radius' | 'fontSize',
+) => {
+  if (size && !(typeof size === 'string') && typeof size === 'object') {
+    return Object.entries(size)
+      .reduce((acc, [key, value]) => ({ ...acc, [key]: inputSizeMaps[prop][value || 'md'] }), {});
+  }
+
+  return inputSizeMaps[prop][size || 'md'] as string;
+};


### PR DESCRIPTION
# Github Issue or Trello Card
This PR addresses this issue: https://github.com/palmetto/palmetto-components/issues/437

Added size + responsive utilities to `TextareaInput` component. 

![Screen Shot 2021-08-16 at 12 14 54 PM](https://user-images.githubusercontent.com/19932356/129595568-6d9b02f5-bc2b-4c97-a23b-2b29ef7c46b5.png)


# What type of change is this?
Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Updating documentation.
- [ ] Updating deployment/build pipeline.

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes

# UI Checklist
- [X] I have conducted visual UAT on my changes/features.
- [X] My solution works well on desktop, tablet, and mobile browsers.