### PR TITLE
fix(TabsSlider): move to element resize observer

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,6 +109,7 @@
     "@types/react-dom": "^16.9.0",
     "@types/react-router-dom": "^5.1.5",
     "@types/react-select": "^3.0.14",
+    "@types/resize-observer-browser": "^0.1.6",
     "@types/uuid": "^8.0.0",
     "@typescript-eslint/eslint-plugin": "^4.0.1",
     "@typescript-eslint/parser": "^4.0.1",

--- a/src/components/TabsSlider/TabsSlider.Playground.stories.tsx
+++ b/src/components/TabsSlider/TabsSlider.Playground.stories.tsx
@@ -17,7 +17,7 @@ export default {
     size: {
       control: {
         type: 'select',
-        options: ['xs', 'sm', 'md', 'lg'],
+        options: ['sm', 'md', 'lg'],
       },
     },
     disabledTabs: {

--- a/src/components/TabsSlider/TabsSlider.test.tsx
+++ b/src/components/TabsSlider/TabsSlider.test.tsx
@@ -2,6 +2,21 @@ import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { TabsSlider, tabsSliderSizes, tabsSliderPaddingMap } from './TabsSlider';
 
+// Mocking ResizeObserver since it is not available to jest runner.
+class ResizeObserver {
+  observe() {
+      // do nothing
+  }
+  unobserve() {
+      // do nothing
+  }
+  disconnect() {
+
+  }
+}
+
+window.ResizeObserver = ResizeObserver;
+
 describe('TabsSlider', () => {
   describe('Default', () => {
     test('It renders basic tabs structure by default', () => {

--- a/src/components/TabsSlider/TabsSlider.test.tsx
+++ b/src/components/TabsSlider/TabsSlider.test.tsx
@@ -4,6 +4,7 @@ import { TabsSlider, tabsSliderSizes, tabsSliderPaddingMap } from './TabsSlider'
 
 // Mocking ResizeObserver since it is not available to jest runner.
 class ResizeObserver {
+  /* eslint-disable */
   observe() {
       // do nothing
   }
@@ -13,6 +14,7 @@ class ResizeObserver {
   disconnect() {
 
   }
+  /* eslint-enable */
 }
 
 window.ResizeObserver = ResizeObserver;

--- a/src/components/TabsSlider/TabsSlider.tsx
+++ b/src/components/TabsSlider/TabsSlider.tsx
@@ -141,11 +141,26 @@ const TabsSliderBaseComponent: React.FC<TabsSliderProps> = React.forwardRef<HTML
     }
   }, [getTabsMeta, indicatorStyle.left, indicatorStyle.width]);
 
-  useEffect(() => {
-    window.addEventListener('resize', updateIndicatorState);
+  const observer = useRef(
+    new ResizeObserver(() => {
+      updateIndicatorState();
+    }),
+  );
 
-    return () => { window.removeEventListener('resize', updateIndicatorState); };
-  }, [updateIndicatorState]);
+  useEffect(() => {
+    const currentNode = tabsRef.current;
+    const currentObserver = observer.current;
+
+    if (currentNode) {
+      currentObserver.observe(currentNode);
+    }
+
+    return () => {
+      if (currentNode) {
+        currentObserver.unobserve(currentNode);
+      }
+    };
+  }, [tabsRef, observer]);
 
   useEffect(() => {
     updateIndicatorState();

--- a/yarn.lock
+++ b/yarn.lock
@@ -3661,6 +3661,11 @@
     "@types/scheduler" "*"
     csstype "^3.0.2"
 
+"@types/resize-observer-browser@^0.1.6":
+  version "0.1.6"
+  resolved "https://registry.yarnpkg.com/@types/resize-observer-browser/-/resize-observer-browser-0.1.6.tgz#d8e6c2f830e2650dc06fe74464472ff64b54a302"
+  integrity sha512-61IfTac0s9jvNtBCpyo86QeaN8qqpMGHdK0uGKCCIy2dt5/Yk84VduHIdWAcmkC5QvdkPL0p5eWYgUZtHKKUVg==
+
 "@types/resolve@1.17.1":
   version "1.17.1"
   resolved "https://registry.yarnpkg.com/@types/resolve/-/resolve-1.17.1.tgz#3afd6ad8967c77e4376c598a82ddd58f46ec45d6"


### PR DESCRIPTION
# Github Issue or Trello Card
This PR addresses this issue: https://github.com/palmetto/palmetto-components/issues/566

While the original implementation worked in almost every case, we did run into some cases like noted in the issue above, where the initial rendering of the selected tab indicator would have the wrong width. Currently the width is updated when any of a number of things happen, such as:

* window size changes.
* active tab changes
* children prop in the component changes.

it seems that this wasn't enough to cover situations in which width changes are triggered by unforeseen cascading of rendering changes when the component interacts with a complex page. 

The solution was to rely on the `ResizeObserver` api to track resizing specific to our component's room DOM node, as opposed to only the window resizing or the state changing. 

NOTE: for performance reasons we can also in the future optimize this to debounce based on observations but have yet seen nothing to indicate it is a problem since the resize observer is capped at running once per animation frame.

# What type of change is this?
Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Updating documentation.
- [ ] Updating deployment/build pipeline.

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes

# UI Checklist
- [X] I have conducted visual UAT on my changes/features.
- [X] My solution works well on desktop, tablet, and mobile browsers.