### PR TITLE
fix: export font-family css var design tokens and correct documentation

### DIFF
--- a/src/docs/FontFamily.stories.mdx
+++ b/src/docs/FontFamily.stories.mdx
@@ -1,16 +1,14 @@
 import { Meta } from '@storybook/addon-docs/blocks';
 import { asset } from '@palmetto/palmetto-design-tokens/build/js/variables-asset';
 
-<Meta
-  title="Design Tokens/Font Family"
-/>
+<Meta title="Design Tokens/Font Family" />
 
 # Font Family
 
 Use these tokens for `font-family`.
 
 <table>
-<thead>
+  <thead>
     <tr>
       <th>token name</th>
       <th>prop value</th>
@@ -20,8 +18,12 @@ Use these tokens for `font-family`.
   <tbody>
     {Object.entries(asset.fonts).map(([name, entry], i) => (
       <tr key={i}>
-        <td><code>{`font-family-${name}`}</code></td>
-        <td><code>{name}</code></td>
+        <td>
+          <code>{`asset-fonts-${name}`}</code>
+        </td>
+        <td>
+          <code>{name}</code>
+        </td>
         <td>{entry.value}</td>
       </tr>
     ))}

--- a/src/styles/variables/tokens.scss
+++ b/src/styles/variables/tokens.scss
@@ -1,2 +1,3 @@
+@import '~@palmetto/palmetto-design-tokens/build/css/variables-asset.css';
 @import '~@palmetto/palmetto-design-tokens/build/css/variables-color.css';
 @import '~@palmetto/palmetto-design-tokens/build/css/variables-size.css';


### PR DESCRIPTION
# Github Issue or Trello Card
We're currently not making the font family design tokens available as css variables. This PR fixes that as well as corrects the variable names in the documenation. 

# What type of change is this?
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Updating documentation.
- [ ] Updating deployment/build pipeline.
- [ ] Updating Project Dependencies
- [ ] Improving or adding to Test Coverage

# Completeness Checklist

- [ ] TESTS: My changes maintain the baseline required test coverage, as specified by code climate analysis.
- [ ] DOCS: All new component work is covered in that component's `Overview` docs.
- [ ] DOCS: All new component work is covered in a component `Playground`.
- [ ] DOCS: All new visual changes or options are covered under relevant components' `VisualTests`.
- [ ] My code has no linting or typescript compile warnings.
- [ ] My work is tied to a Github issue and satisfies the acceptance criteria (if applicable) of the corresponding issue.

# Quality Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

# UI Checklist
- [ ] I have conducted visual UAT on my changes/features.
- [ ] My solution works well on desktop, tablet, and mobile browsers.