### PR TITLE
docs(createComponent): correct border width prop name

### DIFF
--- a/src/lib/createComponent/createComponent.Overview.stories.mdx
+++ b/src/lib/createComponent/createComponent.Overview.stories.mdx
@@ -7,7 +7,7 @@ import { createComponent } from './createComponent';
 
 # Creating Custom Components
 
-Our library encourages usage of the `Box` component frequently due to its extensability and flexibility, and in fact most other components are based on it.
+Our library encourages usage of the `Box` component frequently due to its extensibility and flexibility, and in fact most other components are based on it.
 This however can lead to markup that can be hard to read in some cases. Consider the example of this basic column layout:
 
 <Canvas isExpanded>
@@ -16,7 +16,7 @@ This however can lead to markup that can be hard to read in some cases. Consider
     direction="row"
     shadow="sm"
     radius="sm"
-    border="xs"
+    borderWidth="xs"
     borderColor="grey-lighter"
     hover={{
       shadow: 'md',
@@ -94,7 +94,7 @@ export const App = () => (
     direction="row"
     shadow="sm"
     radius="sm"
-    border="xs"
+    borderWidth="xs"
     borderColor="grey-lighter"
     hover={{
       shadow: 'md',
@@ -177,7 +177,7 @@ export const App = () => {
       direction="row"
       shadow="sm"
       radius="sm"
-      border="xs"
+      borderWidth="xs"
       borderColor="grey-lighter"
       hover={{
         shadow: 'md',
@@ -318,7 +318,7 @@ const MainContainer = createComponent(Box)({
   direction: 'row',
   shadow: 'sm',
   radius: 'sm',
-  border: 'xs',
+  borderWidth: 'xs',
   borderColor: 'grey-lighter',
   hover: {
     shadow: 'md',
@@ -364,7 +364,7 @@ custom components. Read on for an example.
       direction: 'row',
       shadow: 'sm',
       radius: 'sm',
-      border: 'xs',
+      borderWidth: 'xs',
       borderColor: 'grey-lighter',
       hover: {
         shadow: 'md',


### PR DESCRIPTION
# Github Issue or Trello Card

Corrects the border width prop name from `border` to `borderWidth`

# What type of change is this?
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Updating documentation.
- [ ] Updating deployment/build pipeline.
- [ ] Updating Project Dependencies
- [ ] Improving or adding to Test Coverage

# Completeness Checklist

- [ ] TESTS: My changes maintain the baseline required test coverage, as specified by code climate analysis.
- [ ] DOCS: All new component work is covered in that component's `Overview` docs.
- [ ] DOCS: All new component work is covered in a component `Playground`.
- [ ] DOCS: All new visual changes or options are covered under relevant components' `VisualTests`.
- [ ] My code has no linting or typescript compile warnings.
- [ ] My work is tied to a Github issue and satisfies the acceptance criteria (if applicable) of the corresponding issue.

# Quality Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

# UI Checklist
- [ ] I have conducted visual UAT on my changes/features.
- [ ] My solution works well on desktop, tablet, and mobile browsers.