### PR TITLE
fix(modal): prevent full screen modal from overflowing beyond safe viewport area

### DIFF
--- a/src/components/Modal/Modal.module.scss
+++ b/src/components/Modal/Modal.module.scss
@@ -93,10 +93,10 @@
 :global([data-reach-dialog-overlay].fullscreen) {
   [data-reach-dialog-content] {
     position: fixed;
-    top: env(safe-area-inset-top);
-    right: env(safe-area-inset-right);
-    bottom: env(safe-area-inset-bottom);
-    left: env(safe-area-inset-left);
+    top: env(safe-area-inset-top, 0);
+    right: env(safe-area-inset-right, 0);
+    bottom: env(safe-area-inset-bottom, 0);
+    left: env(safe-area-inset-left, 0);
     border-radius: 0;
   }
 

--- a/src/components/Modal/Modal.module.scss
+++ b/src/components/Modal/Modal.module.scss
@@ -93,10 +93,10 @@
 :global([data-reach-dialog-overlay].fullscreen) {
   [data-reach-dialog-content] {
     position: fixed;
-    top: 0;
-    right: 0;
-    bottom: 0;
-    left: 0;
+    top: env(safe-area-inset-top);
+    right: env(safe-area-inset-right);
+    bottom: env(safe-area-inset-bottom);
+    left: env(safe-area-inset-left);
     border-radius: 0;
   }
 


### PR DESCRIPTION
# Github Issue or Trello Card
This PR addresses this issue: https://github.com/palmetto/palmetto-components/issues/672

Before: 
![image](https://user-images.githubusercontent.com/16456162/150879254-17ee6f27-6be4-459d-9795-54c2d8ad62bb.png)

After:
![image](https://user-images.githubusercontent.com/16456162/150879284-53ebf8d2-4fbc-4520-b21c-d91ef7e11d92.png)


# What type of change is this?
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Completeness Checklist

- [x] TESTS: My changes maintain the baseline required test coverage, as specified by code climate analysis.
- [x] DOCS: All new component work is covered in that component's `Overview` docs.
- [x] DOCS: All new component work is covered in a component `Playground`.
- [x] DOCS: All new visual changes or options are covered under relevant components' `VisualTests`.
  - The changes are only relevant in app
- [x] My code has no linting or typescript compile warnings.
- [x] My work is tied to a Github issue and satisfies the acceptance criteria (if applicable) of the corresponding issue.

# Quality Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
  - I added a screenshot to this PR showing the change using XCode Simulator
- [x] New and existing unit tests pass locally with my changes

# UI Checklist
- [x] I have conducted visual UAT on my changes/features.
- [x] My solution works well on desktop, tablet, and mobile browsers.