### PR TITLE
feat(Heading): document and enable theming

### DIFF
--- a/src/components/Alert/Alert.Overview.stories.mdx
+++ b/src/components/Alert/Alert.Overview.stories.mdx
@@ -25,7 +25,6 @@ Use alerts to display feedback for users about specific actions, or states of an
 
 <ArgsTable of={Alert} />
 
-
 ## Default
 
 All that is required to render a basic version of an Alert is a `message` prop which will contain text
@@ -228,7 +227,6 @@ Renders a version of the banner with less padding.
   </Story>
 </Canvas>
 
-
 ## Custom Theming
 
 The Alert component can be themed by overrriding by overrriding specific CSS variables.
@@ -236,10 +234,12 @@ The Alert component can be themed by overrriding by overrriding specific CSS var
 <Canvas>
   <Story name="With Custom Theme">
     <>
-      <div style={{
-        '--color-brand-info-50': '#CFC5E9',
-        '--color-brand-info-500': '#603FB5',
-      }}>
+      <div
+        style={{
+          '--color-brand-info-50': '#CFC5E9',
+          '--color-brand-info-500': '#603FB5',
+        }}
+      >
         <Alert
           message="Here we've overwritten base token values so that the alert inherits new values."
           title="Custom Theme"
@@ -248,14 +248,16 @@ The Alert component can be themed by overrriding by overrriding specific CSS var
           className="m-bottom-md"
         />
       </div>
-      <div style={{
-        '--alert-info-font-color': '#603FB5',
-        '--alert-info-background-color': 'white',
-        '--alert-info-icon-color': '#603FB5',
-        '--alert-border-width': 'var(--size-border-xs)',
-        '--alert-info-border-color': 'var(--alert-info-icon-color)',
-        '--alert-box-shadow': '0 2px 4px 0 #CFC5E9, 0 1px 2px 0 #CFC5E9'
-      }}>
+      <div
+        style={{
+          '--alert-info-font-color': '#603FB5',
+          '--alert-info-background-color': 'white',
+          '--alert-info-icon-color': '#603FB5',
+          '--alert-border-width': 'var(--size-border-xs)',
+          '--alert-info-border-color': 'var(--alert-info-icon-color)',
+          '--alert-box-shadow': '0 2px 4px 0 #CFC5E9, 0 1px 2px 0 #CFC5E9',
+        }}
+      >
         <Alert
           message="Here we've overwritten ONLY the values for the 'info' alert variant so other components will be unaffected"
           title="Custom Theme"
@@ -268,7 +270,7 @@ The Alert component can be themed by overrriding by overrriding specific CSS var
   </Story>
 </Canvas>
 
-## Themable Tokens
+## Component Tokens
 
 <table>
   <thead>
@@ -305,10 +307,15 @@ The Alert component can be themed by overrriding by overrriding specific CSS var
         '--alert-box-shadow': '--size-box-shadow-0',
       };
       return Object.entries(tokens).map(([name, entry], i) => (
-      <tr key={i}>
-        <td><code>{name}</code></td>
-        <td><code>{entry}</code></td>
-      </tr>
-    ))})()}
+        <tr key={i}>
+          <td>
+            <code>{name}</code>
+          </td>
+          <td>
+            <code>{entry}</code>
+          </td>
+        </tr>
+      ));
+    })()}
   </tbody>
 </table>

--- a/src/components/Alert/Alert.Overview.stories.mdx
+++ b/src/components/Alert/Alert.Overview.stories.mdx
@@ -229,7 +229,7 @@ Renders a version of the banner with less padding.
 
 ## Custom Theming
 
-The Alert component can be themed by overrriding by overrriding specific CSS variables.
+The Alert component can be themed by base tokens, or component specific tokens.
 
 <Canvas>
   <Story name="With Custom Theme">
@@ -255,7 +255,6 @@ The Alert component can be themed by overrriding by overrriding specific CSS var
           '--alert-info-icon-color': '#603FB5',
           '--alert-border-width': 'var(--size-border-xs)',
           '--alert-info-border-color': 'var(--alert-info-icon-color)',
-          '--alert-box-shadow': '0 2px 4px 0 #CFC5E9, 0 1px 2px 0 #CFC5E9',
         }}
       >
         <Alert
@@ -264,6 +263,12 @@ The Alert component can be themed by overrriding by overrriding specific CSS var
           variant="info"
           hasIcon
           className="m-bottom-md"
+        />
+        <Alert
+          message="An alert that uses default token values"
+          variant="warning"
+          title="Not Themed"
+          hasIcon
         />
       </div>
     </>

--- a/src/components/Heading/Heading.Overview.stories.mdx
+++ b/src/components/Heading/Heading.Overview.stories.mdx
@@ -79,3 +79,34 @@ The variant of the heading is inherited from its parent, but can be set to brand
     </>
   </Story>
 </Canvas>
+
+## Component Tokens
+
+<table>
+  <thead>
+    <tr>
+      <th>token name</th>
+      <th>default value</th>
+    </tr>
+  </thead>
+  <tbody>
+    {(() => {
+      const tokens = {
+      '--heading-font-family': '--asset-fonts-brand',
+      '--heading-font-weight': '--size-font-weight-black',
+      '--heading-line-height': '--size-line-height-heading',
+      };
+      return Object.entries(tokens).map(([name, entry], i) => (
+        <tr key={i}>
+          <td>
+            <code>{name}</code>
+          </td>
+          <td>
+            <code>{entry}</code>
+          </td>
+        </tr>
+      ));
+    })()}
+
+  </tbody>
+</table>

--- a/src/components/Heading/Heading.module.scss
+++ b/src/components/Heading/Heading.module.scss
@@ -1,5 +1,5 @@
 .heading {
-  line-height: var(--heading-line-height);
-  font-family: var(--heading-font-family);
-  font-weight: var(--heading-font-weight);
+  line-height: var(--heading-line-height, var(--size-line-height-heading));
+  font-family: var(--heading-font-family, var(--asset-fonts-brand));
+  font-weight: var(--heading-font-weight, var(--size-font-weight-black));
 }

--- a/src/components/Heading/Heading.tsx
+++ b/src/components/Heading/Heading.tsx
@@ -51,7 +51,6 @@ export const Heading: FC<HeadingProps> = ({
   const headingSize = size || HEADING_DEFAULT_SIZE_MAP[as];
 
   const classes = classNames(
-    'palmetto-components__variables__heading',
     styles.heading,
     className,
     generateResponsiveClasses('font-size', headingSize),

--- a/src/styles/variables/headings.scss
+++ b/src/styles/variables/headings.scss
@@ -1,5 +1,0 @@
-.palmetto-components__variables__heading {
-  --heading-font-family: var(--asset-fonts-brand);
-  --heading-font-weight: var(--size-font-weight-black);
-  --heading-line-height: var(--size-line-height-heading);
-}

--- a/src/styles/variables/index.scss
+++ b/src/styles/variables/index.scss
@@ -5,4 +5,3 @@
 @import './modal';
 @import './table';
 @import './links';
-@import './headings';

--- a/yarn.lock
+++ b/yarn.lock
@@ -2266,10 +2266,10 @@
   dependencies:
     "@octokit/openapi-types" "^7.2.3"
 
-"@palmetto/palmetto-design-tokens@0.60.1":
-  version "0.60.1"
-  resolved "https://registry.yarnpkg.com/@palmetto/palmetto-design-tokens/-/palmetto-design-tokens-0.60.1.tgz#071cc25a2bbc2b4e8f4e38728097c5bc8c2fb70d"
-  integrity sha512-/65yKrhmPf03K1vo70kP1ZmRKY7k3IasPbOxJMMF3IweOdYkXJ/gooqwat0I8qaW0I5c42evQ60hHMajOoocVw==
+"@palmetto/palmetto-design-tokens@0.60.4":
+  version "0.60.4"
+  resolved "https://registry.yarnpkg.com/@palmetto/palmetto-design-tokens/-/palmetto-design-tokens-0.60.4.tgz#76ec8a18db030b2e7797903afa6d214a97d7e754"
+  integrity sha512-hlLNmgum6WPWB/wI8TYQ7D/XRjrQj2ZAGuVEj8R5EJij2+dIPMUhs9lZXfxbh5KAy2rPgbTgmLpXAcn9aQbldA==
 
 "@pmmmwh/react-refresh-webpack-plugin@^0.4.3":
   version "0.4.3"


### PR DESCRIPTION
# Github Issue or Trello Card

Allows font-family, font-weight, and line-height to be themed for the Heading component

This PR addresses this issue: https://trello.com/c/0BYfsU0F/1147-update-components-for-themability

# What type of change is this?
Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Updating documentation.
- [ ] Updating deployment/build pipeline.
- [ ] Updating Project Dependencies
- [ ] Improving or adding to Test Coverage

# Completeness Checklist

- [ ] TESTS: My changes maintain the baseline required test coverage, as specified by code climate analysis.
- [ ] DOCS: All new component work is covered in that component's `Overview` docs.
- [ ] DOCS: All new component work is covered in a component `Playground`.
- [ ] DOCS: All new visual changes or options are covered under relevant components' `VisualTests`.
- [ ] My code has no linting or typescript compile warnings.
- [ ] My work is tied to a Github issue and satisfies the acceptance criteria (if applicable) of the corresponding issue.

# Quality Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

# UI Checklist
- [ ] I have conducted visual UAT on my changes/features.
- [ ] My solution works well on desktop, tablet, and mobile browsers.