### PR TITLE
Fix: [732] Implement Stricter ButtonProps

### DIFF
--- a/src/components/Button/Button.Playground.stories.tsx
+++ b/src/components/Button/Button.Playground.stories.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Meta, Story } from '@storybook/react/types-6-0';
 import { ICON_NAMES } from '../../lib/tokens';
-import { Button, ButtonProps } from './Button';
+import { Button, StrictButtonProps } from './Button';
 import { BUTTON_SIZES, BUTTON_VARIANTS } from './Button.constants';
 
 export default {
@@ -77,7 +77,7 @@ export default {
   },
 } as Meta;
 
-const Template: Story<ButtonProps> = ({ ...args }) => <Button {...args} />;
+const Template: Story<StrictButtonProps> = ({ ...args }) => <Button {...args} />;
 
 export const Playground = Template.bind({});
 Playground.args = {

--- a/src/components/Button/Button.Playground.stories.tsx
+++ b/src/components/Button/Button.Playground.stories.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Meta, Story } from '@storybook/react/types-6-0';
 import { ICON_NAMES } from '../../lib/tokens';
-import { Button, StrictButtonProps } from './Button';
+import { Button, ButtonProps } from './Button';
 import { BUTTON_SIZES, BUTTON_VARIANTS } from './Button.constants';
 
 export default {
@@ -77,7 +77,7 @@ export default {
   },
 } as Meta;
 
-const Template: Story<StrictButtonProps> = ({ ...args }) => <Button {...args} />;
+const Template: Story<ButtonProps> = ({ ...args }) => <Button {...args} />;
 
 export const Playground = Template.bind({});
 Playground.args = {

--- a/src/components/Button/Button.VisualTests.stories.tsx
+++ b/src/components/Button/Button.VisualTests.stories.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Meta, Story } from '@storybook/react/types-6-0';
 import { within } from '@storybook/testing-library';
-import { Button, StrictButtonProps } from './Button';
+import { Button, ButtonProps } from './Button';
 import { BUTTON_SIZES, BUTTON_VARIANTS } from './Button.constants';
 import { Box } from '../Box/Box';
 import { RESPONSIVE_STORY } from '../../docs/constants';
@@ -11,7 +11,7 @@ export default {
   component: Button,
 } as Meta;
 
-const Template: Story<StrictButtonProps & { showIconButton: boolean; }> = (args, showIconButton) => (
+const Template: Story<ButtonProps & { showIconButton: boolean; }> = (args, showIconButton) => (
   <Box childGap="xl">
     {BUTTON_SIZES.map(size => (
       <Box childGap="sm" key={size}>
@@ -71,7 +71,7 @@ const Template: Story<StrictButtonProps & { showIconButton: boolean; }> = (args,
   </Box>
 );
 
-const SingleButtonTemplate: Story<StrictButtonProps> = args => (
+const SingleButtonTemplate: Story<ButtonProps> = args => (
   // the div is to add padding so that chromatic captures the box-shadow focus state
   <div className="p-md">
     <Button {...args}>label</Button>

--- a/src/components/Button/Button.VisualTests.stories.tsx
+++ b/src/components/Button/Button.VisualTests.stories.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Meta, Story } from '@storybook/react/types-6-0';
 import { within } from '@storybook/testing-library';
-import { Button, ButtonProps } from './Button';
+import { Button, StrictButtonProps } from './Button';
 import { BUTTON_SIZES, BUTTON_VARIANTS } from './Button.constants';
 import { Box } from '../Box/Box';
 import { RESPONSIVE_STORY } from '../../docs/constants';
@@ -11,7 +11,7 @@ export default {
   component: Button,
 } as Meta;
 
-const Template: Story<ButtonProps> = (args, showIconButton) => (
+const Template: Story<StrictButtonProps & { showIconButton: boolean; }> = (args, showIconButton) => (
   <Box childGap="xl">
     {BUTTON_SIZES.map(size => (
       <Box childGap="sm" key={size}>
@@ -71,7 +71,7 @@ const Template: Story<ButtonProps> = (args, showIconButton) => (
   </Box>
 );
 
-const SingleButtonTemplate: Story<ButtonProps> = args => (
+const SingleButtonTemplate: Story<StrictButtonProps> = args => (
   // the div is to add padding so that chromatic captures the box-shadow focus state
   <div className="p-md">
     <Button {...args}>label</Button>

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -1,5 +1,5 @@
 import React, {
-  FC, ReactNode, MouseEvent, FocusEvent, forwardRef, createElement, AnchorHTMLAttributes,
+  ReactNode, MouseEvent, FocusEvent, forwardRef, createElement, AnchorHTMLAttributes,
 } from 'react';
 import classNames from 'classnames';
 import { IconName, ResponsiveProp } from '../../types';
@@ -99,6 +99,9 @@ interface BaseButtonProps {
       * The color variant of the button
       */
      variant?: ButtonVariant;
+     /**
+      * ref - currently cannot be typed due to limitations of using the `as` prop
+      */
 }
 
 /**
@@ -122,7 +125,7 @@ type NormalButtonProps = { as?: 'button'; } &
 
 export type StrictButtonProps = NormalButtonProps | AnchorButtonProps
 
-export const Button: FC<StrictButtonProps> = forwardRef(
+export const Button = forwardRef<HTMLAnchorElement | HTMLButtonElement, StrictButtonProps>(
   (
     {
       children = undefined,

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -14,101 +14,115 @@ import styles from './Button.module.scss';
 export type ButtonVariant = 'primary' | 'success' | 'danger' | 'light' | 'dark' | 'white';
 
 export type ButtonSize = 'xs' | 'sm' | 'md' | 'lg';
-export interface ButtonProps {
-  /**
-   * Contents of the button.
-   */
-  children?: ReactNode;
+
+interface BaseButtonProps {
+     /**
+      * Contents of the button.
+      */
+     children?: ReactNode;
+     /**
+      * Additional ClassNames to add to button.
+      */
+     className?: string;
+     /**
+      * Button takes up the full width of its parent container.
+      */
+     fullWidth?: boolean;
+     /**
+      * Name of the icon to include before the button text
+      */
+     iconPrefix?: IconName;
+     /**
+      * Name of the icon to include after the button text
+      */
+     iconSuffix?: IconName;
+     /**
+      * A unique identifier for the button.
+      */
+     id?: string;
+     /**
+      * URL to navigate to when clicked. Passing this attribute automatically
+      * renders an anchor <a> tag, NOT a <button> element.
+      */
+     href?: string;
+     /**
+      * Disables the button, making it inoperable.
+      */
+     isDisabled?: boolean;
+     /**
+      * Replaces the button text with a loading indicator and disables the button.
+      */
+     isLoading?: boolean;
+     /**
+      * Renders an outline version of the button. With a transparent background.
+      */
+     isOutlined?: boolean;
+     /**
+      * Render the button with no styles of its own, other than a pointer cursor.
+      */
+     isNaked?: boolean;
+     /**
+      * Prop reserved for when component is wrapped by `<Link>` from react-router.
+      */
+     navigate?: () => void;
+     /**
+      * Callback when Button is pressed.
+      */
+     onClick?: (event: MouseEvent<HTMLButtonElement | HTMLAnchorElement>) => void;
+     /**
+      * Callback when focus leaves Button.
+      */
+     onBlur?: (event: FocusEvent<HTMLButtonElement | HTMLAnchorElement>) => void;
+     /**
+      * Callback when Button receives focus.
+      */
+     onFocus?: (event: FocusEvent<HTMLButtonElement | HTMLAnchorElement>) => void;
+     /**
+      * Specify the tabIndex of the button.
+      */
+     tabIndex?: number;
+     /**
+      * Useful when using button as an anchor tag.
+      */
+     target?: AnchorHTMLAttributes<HTMLAnchorElement>['target'];
+     /**
+      * The Button's type.
+      * NOTE: this is not restricted to button types since we allow
+      * rendering a button as a different HTML element than a button (`<a>` or `<input>`).
+      */
+     type?: 'submit' | 'reset' | 'button' | string;
+     /**
+      * The size of the button.
+      */
+     size?: ButtonSize | ResponsiveProp<ButtonSize>;
+     /**
+      * The color variant of the button
+      */
+     variant?: ButtonVariant;
+}
+
+/**
+ * @deprecated use StrictBoxProps instead
+ */
+export interface ButtonProps extends BaseButtonProps {
   /**
    * HTML element that will be rendered.
    */
   as?: 'button' | 'a';
-  /**
-   * Additional ClassNames to add to button.
-   */
-  className?: string;
-  /**
-   * Button takes up the full width of its parent container.
-   */
-  fullWidth?: boolean;
-  /**
-   * Name of the icon to include before the button text
-   */
-  iconPrefix?: IconName;
-  /**
-   * Name of the icon to include after the button text
-   */
-  iconSuffix?: IconName;
-  /**
-   * A unique identifier for the button.
-   */
-  id?: string;
-  /**
-   * URL to navigate to when clicked. Passing this attribute automatically
-   * renders an anchor <a> tag, NOT a <button> element.
-   */
-  href?: string;
-  /**
-   * Disables the button, making it inoperable.
-   */
-  isDisabled?: boolean;
-  /**
-   * Replaces the button text with a loading indicator and disables the button.
-   */
-  isLoading?: boolean;
-  /**
-   * Renders an outline version of the button. With a transparent background.
-   */
-  isOutlined?: boolean;
-  /**
-   * Render the button with no styles of its own, other than a pointer cursor.
-   */
-  isNaked?: boolean;
-  /**
-   * Prop reserved for when component is wrapped by `<Link>` from react-router.
-   */
-  navigate?: () => void;
-  /**
-   * Callback when Button is pressed.
-   */
-  onClick?: (event: MouseEvent<HTMLButtonElement | HTMLAnchorElement>) => void;
-  /**
-   * Callback when focus leaves Button.
-   */
-  onBlur?: (event: FocusEvent<HTMLButtonElement | HTMLAnchorElement>) => void;
-  /**
-   * Callback when Button receives focus.
-   */
-  onFocus?: (event: FocusEvent<HTMLButtonElement | HTMLAnchorElement>) => void;
-  /**
-   * Specify the tabIndex of the button.
-   */
-  tabIndex?: number;
-  /**
-   * Useful when using button as an anchor tag.
-   */
-  target?: AnchorHTMLAttributes<HTMLAnchorElement>['target'];
-  /**
-   * The Button's type.
-   * NOTE: this is not restricted to button types since we allow
-   * rendering a button as a different HTML element than a button (`<a>` or `<input>`).
-   */
-  type?: 'submit' | 'reset' | 'button' | string;
-  /**
-   * The size of the button.
-   */
-  size?: ButtonSize | ResponsiveProp<ButtonSize>;
-  /**
-   * The color variant of the button
-   */
-  variant?: ButtonVariant;
   /**
    * Additional props to be spread to rendered element
    */
   [x: string]: any; // eslint-disable-line
 }
 
-export const Button: FC<ButtonProps> = forwardRef(
+type AnchorButtonProps = { as: 'a'; } &
+  BaseButtonProps & Omit<JSX.IntrinsicElements['a'], 'ref'>
+type NormalButtonProps = { as?: 'button'; } &
+  BaseButtonProps & Omit<JSX.IntrinsicElements['button'], 'ref'>
+
+export type StrictButtonProps = NormalButtonProps | AnchorButtonProps
+
+export const Button: FC<StrictButtonProps> = forwardRef(
   (
     {
       children = undefined,

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -104,28 +104,15 @@ interface BaseButtonProps {
       */
 }
 
-/**
- * @deprecated use StrictBoxProps instead
- */
-export interface ButtonProps extends BaseButtonProps {
-  /**
-   * HTML element that will be rendered.
-   */
-  as?: 'button' | 'a';
-  /**
-   * Additional props to be spread to rendered element
-   */
-  [x: string]: any; // eslint-disable-line
-}
-
 type AnchorButtonProps = { as: 'a'; } &
   BaseButtonProps & Omit<JSX.IntrinsicElements['a'], 'ref'>
+
 type NormalButtonProps = { as?: 'button'; } &
   BaseButtonProps & Omit<JSX.IntrinsicElements['button'], 'ref'>
 
-export type StrictButtonProps = NormalButtonProps | AnchorButtonProps
+export type ButtonProps = NormalButtonProps | AnchorButtonProps
 
-export const Button = forwardRef<HTMLAnchorElement | HTMLButtonElement, StrictButtonProps>(
+export const Button = forwardRef<HTMLAnchorElement | HTMLButtonElement, ButtonProps>(
   (
     {
       children = undefined,


### PR DESCRIPTION
# Github Issue or Trello Card
This PR addresses this issue:  #732

This PR gives the Button component a more strict type signature to prevent accidental adding of react props to DOM elements. While this wouldn't adversely affect the dotcom team, I'm not familiar with how other teams are using this library so let me know if this would be too much trouble for other users.

I've kept the old `ButtonProps` type signature for backward compatibility in the case where others were using this type for their own components. If it would be preferred to make this a breaking change just to only have one set of props let me know.

# What type of change is this?

- [x] Bug fix (non-breaking change which fixes an issue)

# Completeness Checklist

- [x] TESTS: My changes maintain the baseline required test coverage, as specified by code climate analysis.
- [x] My code has no linting or typescript compile warnings.
- [x] My work is tied to a Github issue and satisfies the acceptance criteria (if applicable) of the corresponding issue.

# Quality Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
