### PR TITLE
feat(Card): enable one-off styling through BoxProps while maintaining theming

### DIFF
--- a/src/components/Card/Card.Overview.stories.mdx
+++ b/src/components/Card/Card.Overview.stories.mdx
@@ -317,6 +317,29 @@ Here are some common use cases of `<Card />`.
   </Story>
 </Canvas>
 
+## Single-Instance Styling
+
+Occasionally, you may want to customize a single instance of a `Card`, but still have the ability to manage the appearance of all other Card instances through its component design token values. We allow single-instance overrides through the use of BoxProps.
+
+**Using any BoxProp whose css attribute matches a component design token's attribute, will mean that all the component's design token values will be ignored. It is assumed that a greater granularity of visual control is desired.**
+
+<Canvas>
+  <Story name="Single-Instance Styling">
+    <Box childGap="xl">
+      <Card>
+        <Card.Section>Default appearance</Card.Section>
+        <Card.Footer>footer</Card.Footer>
+      </Card>
+      <Card shadow="xl" radius="md" background="secondary-50">
+        <Card.Section>Customized appearance using BoxProps</Card.Section>
+        <Card.Footer background="secondary-900" color="grey-100">
+          footer
+        </Card.Footer>
+      </Card>
+    </Box>
+  </Story>
+</Canvas>
+
 ## Component Design Tokens
 
 <table>

--- a/src/components/Card/Card.Overview.stories.mdx
+++ b/src/components/Card/Card.Overview.stories.mdx
@@ -332,6 +332,7 @@ Here are some common use cases of `<Card />`.
         '--card-background-color': '--color-brand-white-500',
         '--card-border-radius': '--size-border-radius-md',
         '--card-box-shadow': '--size-box-shadow-sm',
+        '--card-subdued-background-color': '--color-brand-grey-50',
         '--card-section-border-color': '--color-brand-grey-100',
         '--card-footer-background-color': '--color-brand-grey-50',
       };

--- a/src/components/Card/Card.Overview.stories.mdx
+++ b/src/components/Card/Card.Overview.stories.mdx
@@ -321,17 +321,19 @@ Here are some common use cases of `<Card />`.
 
 Occasionally, you may want to customize a single instance of a `Card`, but still have the ability to manage the appearance of all other Card instances through its component design token values. We allow single-instance overrides through the use of BoxProps.
 
-**Using any BoxProp whose css attribute matches a component design token's attribute, will mean that all the component's design token values will be ignored. It is assumed that a greater granularity of visual control is desired.**
-
 <Canvas>
   <Story name="Single-Instance Styling">
     <Box childGap="xl">
       <Card>
         <Card.Section>Default appearance</Card.Section>
+        <Card.Section>Default appearance</Card.Section>
         <Card.Footer>footer</Card.Footer>
       </Card>
       <Card shadow="xl" radius="sm" background="secondary-50">
         <Card.Section>Customized appearance using BoxProps</Card.Section>
+        <Card.Section borderWidth="sm 0 0 0" borderColor="secondary-100">
+          Customized appearance using BoxProps
+        </Card.Section>
         <Card.Footer background="secondary-900" color="grey-100">
           footer
         </Card.Footer>
@@ -341,10 +343,12 @@ Occasionally, you may want to customize a single instance of a `Card`, but still
           '--card-background-color': 'var(--color-brand-tertiary-50)',
           '--card-footer-background-color': 'var(--color-brand-tertiary-900)',
           '--card-border-radius': 'var(--size-border-radius-lg)',
+          '--card-section-border-color': 'var(--color-brand-tertiary-100)',
           '--card-box-shadow': '0',
         }}
       >
         <Card>
+          <Card.Section>Themed card using component design tokens</Card.Section>
           <Card.Section>Themed card using component design tokens</Card.Section>
           <Card.Footer color="white">footer</Card.Footer>
         </Card>

--- a/src/components/Card/Card.Overview.stories.mdx
+++ b/src/components/Card/Card.Overview.stories.mdx
@@ -330,12 +330,25 @@ Occasionally, you may want to customize a single instance of a `Card`, but still
         <Card.Section>Default appearance</Card.Section>
         <Card.Footer>footer</Card.Footer>
       </Card>
-      <Card shadow="xl" radius="md" background="secondary-50">
+      <Card shadow="xl" radius="sm" background="secondary-50">
         <Card.Section>Customized appearance using BoxProps</Card.Section>
         <Card.Footer background="secondary-900" color="grey-100">
           footer
         </Card.Footer>
       </Card>
+      <div
+        style={{
+          '--card-background-color': 'var(--color-brand-tertiary-50)',
+          '--card-footer-background-color': 'var(--color-brand-tertiary-900)',
+          '--card-border-radius': 'var(--size-border-radius-lg)',
+          '--card-box-shadow': '0',
+        }}
+      >
+        <Card>
+          <Card.Section>Themed card using component design tokens</Card.Section>
+          <Card.Footer color="white">footer</Card.Footer>
+        </Card>
+      </div>
     </Box>
   </Story>
 </Canvas>

--- a/src/components/Card/Card.Overview.stories.mdx
+++ b/src/components/Card/Card.Overview.stories.mdx
@@ -375,6 +375,7 @@ Occasionally, you may want to customize a single instance of a `Card`, but still
         '--card-box-shadow': '--size-box-shadow-sm',
         '--card-subdued-background-color': '--color-brand-grey-50',
         '--card-section-border-color': '--color-brand-grey-100',
+        '--card-section-subdued-border-color': '--color-brand-grey-100',
         '--card-footer-background-color': '--color-brand-grey-50',
       };
       return Object.entries(tokens).map(([name, entry], i) => (

--- a/src/components/Card/Card.Overview.stories.mdx
+++ b/src/components/Card/Card.Overview.stories.mdx
@@ -329,16 +329,8 @@ Occasionally, you may want to customize a single instance of a `Card`, but still
         <Card.Section>Default appearance</Card.Section>
         <Card.Footer>footer</Card.Footer>
       </Card>
-      <Card shadow="xl" radius="sm" background="secondary-50">
-        <Card.Section>Customized appearance using BoxProps</Card.Section>
-        <Card.Section borderWidth="sm 0 0 0" borderColor="secondary-100">
-          Customized appearance using BoxProps
-        </Card.Section>
-        <Card.Footer background="secondary-900" color="grey-100">
-          footer
-        </Card.Footer>
-      </Card>
-      <div
+      <Box
+        childGap="xl"
         style={{
           '--card-background-color': 'var(--color-brand-tertiary-50)',
           '--card-footer-background-color': 'var(--color-brand-tertiary-900)',
@@ -352,7 +344,16 @@ Occasionally, you may want to customize a single instance of a `Card`, but still
           <Card.Section>Themed card using component design tokens</Card.Section>
           <Card.Footer color="white">footer</Card.Footer>
         </Card>
-      </div>
+        <Card shadow="xl" radius="sm" background="secondary-50">
+          <Card.Section>BoxProps are used instead of tokens</Card.Section>
+          <Card.Section borderWidth="sm 0 0 0" borderColor="secondary-100">
+            BoxProps are used instead of tokens
+          </Card.Section>
+          <Card.Footer background="secondary-900" color="grey-100">
+            footer
+          </Card.Footer>
+        </Card>
+      </Box>
     </Box>
   </Story>
 </Canvas>

--- a/src/components/Card/Card.module.scss
+++ b/src/components/Card/Card.module.scss
@@ -19,6 +19,12 @@
   + .card-section-border {
     border-top: 1px solid var(--card-section-border-color, var(--color-brand-grey-100));
   }
+
+  &.card-subdued {
+    + .card-section-border {
+      border-top: 1px solid var(--card-section-subdued-border-color, var(--color-brand-grey-100));
+    }
+  }
 }
 
 .card-footer-background {

--- a/src/components/Card/Card.module.scss
+++ b/src/components/Card/Card.module.scss
@@ -13,17 +13,17 @@
 .card-subdued {
   background-color: var(--card-subdued-background-color, var(--color-brand-grey-50));
   box-shadow: none;
+
+  .card-section-border {
+    + .card-section-border {
+      border-top: 1px solid var(--card-section-subdued-border-color, var(--color-brand-grey-100));
+    }
+  }
 }
 
 .card-section-border {
   + .card-section-border {
     border-top: 1px solid var(--card-section-border-color, var(--color-brand-grey-100));
-  }
-
-  &.card-subdued {
-    + .card-section-border {
-      border-top: 1px solid var(--card-section-subdued-border-color, var(--color-brand-grey-100));
-    }
   }
 }
 

--- a/src/components/Card/Card.module.scss
+++ b/src/components/Card/Card.module.scss
@@ -1,6 +1,6 @@
 .card {
   background-color: var(--card-background-color, var(--color-brand-white-500));
-  border-radius: var(--modal-border-radius, var(--size-border-radius-md));
+  border-radius: var(--card-border-radius, var(--size-border-radius-md));
   box-shadow: var(--card-box-shadow, var(--size-box-shadow-sm));
 
   &.subdued {

--- a/src/components/Card/Card.module.scss
+++ b/src/components/Card/Card.module.scss
@@ -10,6 +10,12 @@
   box-shadow: var(--card-box-shadow, var(--size-box-shadow-sm));
 }
 
+.card-section-border {
+  + .card-section-border {
+    border-top: 1px solid var(--card-section-border-color, var(--color-brand-grey-100));
+  }
+}
+
 .card-subdued {
   background-color: var(--card-subdued-background-color, var(--color-brand-grey-50));
   box-shadow: none;
@@ -18,12 +24,6 @@
     + .card-section-border {
       border-top: 1px solid var(--card-section-subdued-border-color, var(--color-brand-grey-100));
     }
-  }
-}
-
-.card-section-border {
-  + .card-section-border {
-    border-top: 1px solid var(--card-section-border-color, var(--color-brand-grey-100));
   }
 }
 

--- a/src/components/Card/Card.module.scss
+++ b/src/components/Card/Card.module.scss
@@ -19,7 +19,7 @@
     background-color: var(--card-subdued-background-color, var(--color-brand-grey-50));
   }
 
-  & + .card-section {
+  + .card-section {
     border-top: 1px solid var(--card-section-border-color, var(--color-brand-grey-100));
   }
 }

--- a/src/components/Card/Card.module.scss
+++ b/src/components/Card/Card.module.scss
@@ -1,25 +1,30 @@
-.card {
+.card-background {
   background-color: var(--card-background-color, var(--color-brand-white-500));
+}
+
+.card-radius {
   border-radius: var(--card-border-radius, var(--size-border-radius-md));
+}
+
+.card-shadow {
   box-shadow: var(--card-box-shadow, var(--size-box-shadow-sm));
-
-  &.subdued {
-    background-color: var(--card-subdued-background-color, var(--color-brand-grey-50));
-    box-shadow: none;
-  }
 }
 
-.card-footer {
-  background-color: var(--card-footer-background-color, var(--color-brand-grey-50));
-  border-color: var(--card-section-border-color, var(--color-brand-grey-100));
+.card-subdued {
+  background-color: var(--card-subdued-background-color, var(--color-brand-grey-50));
+  box-shadow: none;
 }
 
-.card-section {
-  &.subdued {
-    background-color: var(--card-subdued-background-color, var(--color-brand-grey-50));
-  }
-
-  + .card-section {
+.card-section-border {
+  + .card-section-border {
     border-top: 1px solid var(--card-section-border-color, var(--color-brand-grey-100));
   }
+}
+
+.card-footer-background {
+  background-color: var(--card-footer-background-color, var(--color-brand-grey-50));
+}
+
+.card-footer-border-color {
+  border-color: var(--card-section-border-color, var(--color-brand-grey-100));
 }

--- a/src/components/Card/Card.module.scss
+++ b/src/components/Card/Card.module.scss
@@ -14,6 +14,12 @@
   border-color: var(--card-section-border-color, var(--color-brand-grey-100));
 }
 
-.card-section + .card-section {
-  border-top: 1px solid var(--card-section-border-color, var(--color-brand-grey-100));
+.card-section {
+  &.subdued {
+    background-color: var(--card-subdued-background-color, var(--color-brand-grey-50));
+  }
+
+  & + .card-section {
+    border-top: 1px solid var(--card-section-border-color, var(--color-brand-grey-100));
+  }
 }

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -9,7 +9,7 @@ import styles from './Card.module.scss';
 
 export interface CardProps extends BoxProps {
   /**
-   * If defined as a prop, all themeable styling will be removed.
+   * If defined as a prop, this value will take higher precedence than the corresponding component design token value
    * Any valid [brand color token](/?path=/story/design-tokens-design-tokens--page#color), or a `url()` for an image
    */
   background?: BrandColor;
@@ -22,12 +22,12 @@ export interface CardProps extends BoxProps {
    */
   subdued?: boolean;
   /**
-   * If defined as a prop, all themeable styling will be removed.
+   * If defined as a prop, this value will take higher precedence than the corresponding component design token value
    * Radius of the Card's corners
    */
   radius?: BorderRadiusSize | ResponsiveProp<BorderRadiusSize>;
   /**
-   * If defined as a prop, all themeable styling will be removed.
+   * If defined as a prop, this value will take higher precedence than the corresponding component design token value
    * The size of the drop shadow applied to the Card
    */
   shadow?: BoxShadowSize | ResponsiveProp<BoxShadowSize>;
@@ -49,12 +49,12 @@ const CardBaseComponent: React.FC<CardProps> = React.forwardRef(
     },
     ref,
   ) => {
-    const useTheme = background === undefined && radius === undefined && shadow === undefined;
-
     const classes = classNames(
       {
-        [styles.card]: useTheme,
-        [styles.subdued]: useTheme && subdued,
+        [styles['card-background']]: background === undefined && !subdued,
+        [styles['card-radius']]: radius === undefined,
+        [styles['card-shadow']]: shadow === undefined && !subdued,
+        [styles['card-subdued']]: subdued,
       },
       className,
     );

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -1,10 +1,16 @@
 import React, { ReactNode } from 'react';
 import classNames from 'classnames';
 import { Box, BoxProps } from '../Box/Box';
+import { BorderRadiusSize, BoxShadowSize, BrandColor, ResponsiveProp } from '../../types';
 import { CardFooter, CardHeader, CardSection } from './components';
 import styles from './Card.module.scss';
 
 export interface CardProps extends BoxProps {
+  /**
+   * If defined as a prop, all themeable styling will be removed.
+   * Any valid [brand color token](/?path=/story/design-tokens-design-tokens--page#color), or a `url()` for an image
+   */
+  background?: BrandColor;
   /**
    * The Card's contents.
    */
@@ -13,38 +19,61 @@ export interface CardProps extends BoxProps {
    * visually subdue the appearance of the entire card.
    */
   subdued?: boolean;
+  /**
+   * If defined as a prop, all themeable styling will be removed.
+   * Radius of the Card's corners
+   */
+  radius?: BorderRadiusSize | ResponsiveProp<BorderRadiusSize>;
+  /**
+   * If defined as a prop, all themeable styling will be removed.
+   * The size of the drop shadow applied to the Card
+   */
+  shadow?: BoxShadowSize | ResponsiveProp<BoxShadowSize>;
 }
 
-const CardBaseComponent: React.FC<CardProps> = React.forwardRef((
-  {
-    children,
-    subdued,
-    className = undefined,
-    overflow = 'hidden',
-    display = 'block',
-    width = '100',
-    ...restProps
-  },
-  ref,
-) => {
-  const classes = classNames(styles.card, className,
+const CardBaseComponent: React.FC<CardProps> = React.forwardRef(
+  (
     {
-      [styles.subdued]: subdued,
-    });
+      background = undefined,
+      children,
+      subdued,
+      className = undefined,
+      overflow = 'hidden',
+      display = 'block',
+      radius = undefined,
+      shadow = undefined,
+      width = '100',
+      ...restProps
+    },
+    ref,
+  ) => {
+    const useTheme = background === undefined && radius === undefined && shadow === undefined;
 
-  return (
-    <Box
-      overflow={overflow}
-      display={display}
-      ref={ref}
-      width={width}
-      className={classes}
-      {...restProps}
-    >
-      {children}
-    </Box>
-  );
-});
+    const classes = classNames(
+      {
+        [styles.card]: useTheme,
+        [styles.subdued]: useTheme && subdued,
+      },
+      className,
+    );
+
+    return (
+      <Box
+        background={background}
+        overflow={overflow}
+        display={display}
+        ref={ref}
+        width={width}
+        radius={radius}
+        shadow={shadow}
+        className={classes}
+        {...restProps}
+      >
+        {children}
+      </Box>
+    );
+  },
+);
 
 export interface CardStatic {
   Header: typeof CardHeader;

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -1,7 +1,9 @@
 import React, { ReactNode } from 'react';
 import classNames from 'classnames';
 import { Box, BoxProps } from '../Box/Box';
-import { BorderRadiusSize, BoxShadowSize, BrandColor, ResponsiveProp } from '../../types';
+import {
+  BorderRadiusSize, BoxShadowSize, BrandColor, ResponsiveProp,
+} from '../../types';
 import { CardFooter, CardHeader, CardSection } from './components';
 import styles from './Card.module.scss';
 

--- a/src/components/Card/components/CardFooter/CardFooter.tsx
+++ b/src/components/Card/components/CardFooter/CardFooter.tsx
@@ -10,12 +10,12 @@ export interface CardFooterProps extends BoxProps {
    */
   children?: ReactNode;
   /**
-   * If defined as a prop, all themeable styling will be removed.
+   * If defined as a prop, this value will take higher precedence than the corresponding component design token value
    * Any valid [brand color token](/?path=/story/design-tokens-design-tokens--page#color), or a `url()` for an image
    */
   background?: BrandColor;
   /**
-   * If defined as a prop, all themeable styling will be removed.
+   * If defined as a prop, this value will take higher precedence than the corresponding component design token value
    * Any valid [brand color token](/?path=/story/design-tokens-design-tokens--page#color) for the border color
    * Or a responsive prop with BrandColor for each breakpoint.
    */
@@ -36,9 +36,13 @@ export const CardFooter: FC<CardFooterProps> = ({
   padding = 'md lg',
   ...restProps
 }) => {
-  const useTheme = background === undefined && borderColor === undefined;
-
-  const classes = classNames({ [styles['card-footer']]: useTheme }, className);
+  const classes = classNames(
+    {
+      [styles['card-footer-background']]: background === undefined,
+      [styles['card-footer-border-color']]: borderColor === undefined,
+    },
+    className,
+  );
 
   return (
     <Box

--- a/src/components/Card/components/CardFooter/CardFooter.tsx
+++ b/src/components/Card/components/CardFooter/CardFooter.tsx
@@ -10,12 +10,12 @@ export interface CardFooterProps extends BoxProps {
    */
   children?: ReactNode;
   /**
-   * If defined as a prop, all theme styling will be removed.
+   * If defined as a prop, all themeable styling will be removed.
    * Any valid [brand color token](/?path=/story/design-tokens-design-tokens--page#color), or a `url()` for an image
    */
   background?: BrandColor;
   /**
-   * If defined as a prop, all theme styling will be removed.
+   * If defined as a prop, all themeable styling will be removed.
    * Any valid [brand color token](/?path=/story/design-tokens-design-tokens--page#color) for the border color
    * Or a responsive prop with BrandColor for each breakpoint.
    */

--- a/src/components/Card/components/CardFooter/CardFooter.tsx
+++ b/src/components/Card/components/CardFooter/CardFooter.tsx
@@ -20,6 +20,10 @@ export interface CardFooterProps extends BoxProps {
    * Or a responsive prop with BrandColor for each breakpoint.
    */
   borderColor?: BrandColor;
+  /**
+   * Additional props to be spread to rendered element
+   */
+  [x: string]: any; // eslint-disable-line
 }
 
 export const CardFooter: FC<CardFooterProps> = ({

--- a/src/components/Card/components/CardFooter/CardFooter.tsx
+++ b/src/components/Card/components/CardFooter/CardFooter.tsx
@@ -1,6 +1,7 @@
 import React, { FC, ReactNode } from 'react';
 import classNames from 'classnames';
 import { Box, BoxProps } from '../../../Box/Box';
+import { BrandColor } from '../../../../types';
 import styles from '../../Card.module.scss';
 
 export interface CardFooterProps extends BoxProps {
@@ -9,26 +10,43 @@ export interface CardFooterProps extends BoxProps {
    */
   children?: ReactNode;
   /**
-   * Additional props to be spread to rendered element
+   * If defined as a prop, all theme styling will be removed.
+   * Any valid [brand color token](/?path=/story/design-tokens-design-tokens--page#color), or a `url()` for an image
    */
-  [x: string]: any; // eslint-disable-line
+  background?: BrandColor;
+  /**
+   * If defined as a prop, all theme styling will be removed.
+   * Any valid [brand color token](/?path=/story/design-tokens-design-tokens--page#color) for the border color
+   * Or a responsive prop with BrandColor for each breakpoint.
+   */
+  borderColor?: BrandColor;
 }
 
 export const CardFooter: FC<CardFooterProps> = ({
+  background = undefined,
+  borderColor = undefined,
   borderWidth = 'xs 0 0 0',
   children = null,
   className,
   display = 'block',
   padding = 'md lg',
   ...restProps
-}) => (
-  <Box
-    className={classNames(styles['card-footer'], className)}
-    display={display}
-    padding={padding}
-    borderWidth={borderWidth}
-    {...restProps}
-  >
-    {children}
-  </Box>
-);
+}) => {
+  const useTheme = background === undefined && borderColor === undefined;
+
+  const classes = classNames({ [styles['card-footer']]: useTheme }, className);
+
+  return (
+    <Box
+      className={classes}
+      display={display}
+      padding={padding}
+      background={background}
+      borderColor={borderColor}
+      borderWidth={borderWidth}
+      {...restProps}
+    >
+      {children}
+    </Box>
+  );
+};

--- a/src/components/Card/components/CardHeader/CardHeader.tsx
+++ b/src/components/Card/components/CardHeader/CardHeader.tsx
@@ -15,6 +15,10 @@ export interface CardHeaderProps extends BoxProps {
    * The title of the card
    */
   title?: ReactNode;
+  /**
+   * Additional props to be spread to rendered element
+   */
+  [x: string]: any; // eslint-disable-line
 }
 
 export const CardHeader: FC<CardHeaderProps> = ({

--- a/src/components/Card/components/CardHeader/CardHeader.tsx
+++ b/src/components/Card/components/CardHeader/CardHeader.tsx
@@ -15,10 +15,6 @@ export interface CardHeaderProps extends BoxProps {
    * The title of the card
    */
   title?: ReactNode;
-  /**
-   * Additional props to be spread to rendered element
-   */
-  [x: string]: any; // eslint-disable-line
 }
 
 export const CardHeader: FC<CardHeaderProps> = ({

--- a/src/components/Card/components/CardSection/CardSection.test.jsx
+++ b/src/components/Card/components/CardSection/CardSection.test.jsx
@@ -2,7 +2,7 @@
 import React from 'react';
 import { render } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
-import CardSection from './CardSection';
+import { CardSection } from './CardSection';
 
 describe('Card/CardSection', () => {
   test('lg padding class is applied by default', () => {
@@ -10,9 +10,9 @@ describe('Card/CardSection', () => {
     expect(container.children[0].classList).toContain('p-h-lg');
   });
 
-  test('card as correct background class if subdued', () => {
+  test('card is subdued', () => {
     const { container } = render(<CardSection subdued>subdued</CardSection>);
-    expect(container.children[0].classList).toContain('background-color-grey-lightest');
+    expect(container.children[0].classList).toContain('subdued');
   });
 
   test('title is rendered as h4 if defined as a string', () => {

--- a/src/components/Card/components/CardSection/CardSection.test.jsx
+++ b/src/components/Card/components/CardSection/CardSection.test.jsx
@@ -10,9 +10,9 @@ describe('Card/CardSection', () => {
     expect(container.children[0].classList).toContain('p-h-lg');
   });
 
-  test('card is subdued', () => {
+  test('is subdued', () => {
     const { container } = render(<CardSection subdued>subdued</CardSection>);
-    expect(container.children[0].classList).toContain('subdued');
+    expect(container.children[0].classList).toContain('card-subdued');
   });
 
   test('title is rendered as h4 if defined as a string', () => {

--- a/src/components/Card/components/CardSection/CardSection.tsx
+++ b/src/components/Card/components/CardSection/CardSection.tsx
@@ -58,19 +58,17 @@ export const CardSection: FC<CardSectionProps> = ({
   title = undefined,
   ...restProps
 }) => {
-  const renderTitle =
-    typeof title === 'string' ? (
-      <Box className="m-bottom-md">
-        <Heading as="h4" size="sm" variant="grey">
-          {title}
-        </Heading>
-      </Box>
-    ) : (
-      title
-    );
+  const renderTitle = typeof title === 'string' ? (
+    <Box className="m-bottom-md">
+      <Heading as="h4" size="sm" variant="grey">
+        {title}
+      </Heading>
+    </Box>
+  ) : (
+    title
+  );
 
-  const useTheme =
-    background === undefined && borderColor === undefined && borderWidth === undefined;
+  const useTheme = background === undefined && borderColor === undefined && borderWidth === undefined;
 
   const sectionClasses = classNames(
     {

--- a/src/components/Card/components/CardSection/CardSection.tsx
+++ b/src/components/Card/components/CardSection/CardSection.tsx
@@ -7,18 +7,18 @@ import styles from '../../Card.module.scss';
 
 export interface CardSectionProps extends BoxProps {
   /**
-   * If defined as a prop, all theme styling will be removed.
+   * If defined as a prop, all themeable styling will be removed.
    * Any valid [brand color token](/?path=/story/design-tokens-design-tokens--page#color), or a `url()` for an image
    */
   background?: BrandColor;
   /**
-   * If defined as a prop, all theme styling will be removed.
+   * If defined as a prop, all themeable styling will be removed.
    * Any valid [brand color token](/?path=/story/design-tokens-design-tokens--page#color) for the border color
    * Or a responsive prop with BrandColor for each breakpoint.
    */
   borderColor?: BrandColor;
   /**
-   * If defined as a prop, all theme styling will be removed.
+   * If defined as a prop, all themeable styling will be removed.
    * Width of the section's border
    * Can be a single [border width token](/?path=/story/design-tokens-design-tokens--page#border-width).
    * Can also be a string of [border width tokens](/?path=/story/design-tokens-design-tokens--page#border-width)
@@ -26,7 +26,7 @@ export interface CardSectionProps extends BoxProps {
    * where you can set the border width on all four sides of an element.
    * e.g: "0 sm xs 0" --> top: 0, right: sm, bottom: xs, left: 0;
    */
-   borderWidth?: BorderSize | string | ResponsiveProp<BorderSize | string>;
+  borderWidth?: BorderSize | string | ResponsiveProp<BorderSize | string>;
   /**
    * Contents of the Section.
    */
@@ -58,22 +58,27 @@ export const CardSection: FC<CardSectionProps> = ({
   title = undefined,
   ...restProps
 }) => {
-  const renderTitle = typeof title === 'string' ? (
-    <Box className="m-bottom-md">
-      <Heading as="h4" size="sm" variant="grey">
-        {title}
-      </Heading>
-    </Box>
-  ) : (
-    title
+  const renderTitle =
+    typeof title === 'string' ? (
+      <Box className="m-bottom-md">
+        <Heading as="h4" size="sm" variant="grey">
+          {title}
+        </Heading>
+      </Box>
+    ) : (
+      title
+    );
+
+  const useTheme =
+    background === undefined && borderColor === undefined && borderWidth === undefined;
+
+  const sectionClasses = classNames(
+    {
+      [styles['card-section']]: useTheme,
+      [styles.subdued]: useTheme && subdued,
+    },
+    className,
   );
-
-  const useTheme = background === undefined && borderColor === undefined && borderWidth === undefined;
-
-  const sectionClasses = classNames({
-    [styles['card-section']]: useTheme,
-    [styles.subdued]: subdued && useTheme,
-  }, className);
 
   return (
     <Box

--- a/src/components/Card/components/CardSection/CardSection.tsx
+++ b/src/components/Card/components/CardSection/CardSection.tsx
@@ -2,9 +2,31 @@ import React, { FC, ReactNode } from 'react';
 import classNames from 'classnames';
 import { Box, BoxProps } from '../../../Box/Box';
 import { Heading } from '../../../Heading/Heading';
+import { BorderSize, BrandColor, ResponsiveProp } from '../../../../types';
 import styles from '../../Card.module.scss';
 
 export interface CardSectionProps extends BoxProps {
+  /**
+   * If defined as a prop, all theme styling will be removed.
+   * Any valid [brand color token](/?path=/story/design-tokens-design-tokens--page#color), or a `url()` for an image
+   */
+  background?: BrandColor;
+  /**
+   * If defined as a prop, all theme styling will be removed.
+   * Any valid [brand color token](/?path=/story/design-tokens-design-tokens--page#color) for the border color
+   * Or a responsive prop with BrandColor for each breakpoint.
+   */
+  borderColor?: BrandColor;
+  /**
+   * If defined as a prop, all theme styling will be removed.
+   * Width of the section's border
+   * Can be a single [border width token](/?path=/story/design-tokens-design-tokens--page#border-width).
+   * Can also be a string of [border width tokens](/?path=/story/design-tokens-design-tokens--page#border-width)
+   * that models itself after the css shorthand property,
+   * where you can set the border width on all four sides of an element.
+   * e.g: "0 sm xs 0" --> top: 0, right: sm, bottom: xs, left: 0;
+   */
+   borderWidth?: BorderSize | string | ResponsiveProp<BorderSize | string>;
   /**
    * Contents of the Section.
    */
@@ -21,14 +43,12 @@ export interface CardSectionProps extends BoxProps {
    * Title for the section.
    */
   title?: ReactNode;
-  /**
-   * Additional props to be spread to rendered element
-   */
-  [x: string]: any; // eslint-disable-line
 }
 
 export const CardSection: FC<CardSectionProps> = ({
   background = undefined,
+  borderColor = undefined,
+  borderWidth = undefined,
   children = null,
   childGap = undefined,
   className = undefined,
@@ -38,8 +58,6 @@ export const CardSection: FC<CardSectionProps> = ({
   title = undefined,
   ...restProps
 }) => {
-  const backgroundColor = subdued ? 'grey-lightest' : background;
-
   const renderTitle = typeof title === 'string' ? (
     <Box className="m-bottom-md">
       <Heading as="h4" size="sm" variant="grey">
@@ -50,11 +68,18 @@ export const CardSection: FC<CardSectionProps> = ({
     title
   );
 
-  const sectionClasses = classNames(styles['card-section'], className);
+  const useTheme = background === undefined && borderColor === undefined && borderWidth === undefined;
+
+  const sectionClasses = classNames({
+    [styles['card-section']]: useTheme,
+    [styles.subdued]: subdued && useTheme,
+  }, className);
 
   return (
     <Box
-      background={backgroundColor}
+      background={background}
+      borderColor={borderColor}
+      borderWidth={borderWidth}
       className={sectionClasses}
       display={display}
       padding={padding}

--- a/src/components/Card/components/CardSection/CardSection.tsx
+++ b/src/components/Card/components/CardSection/CardSection.tsx
@@ -7,18 +7,18 @@ import styles from '../../Card.module.scss';
 
 export interface CardSectionProps extends BoxProps {
   /**
-   * If defined as a prop, all themeable styling will be removed.
+   * If defined as a prop, this value will take higher precedence than the corresponding component design token value
    * Any valid [brand color token](/?path=/story/design-tokens-design-tokens--page#color), or a `url()` for an image
    */
   background?: BrandColor;
   /**
-   * If defined as a prop, all themeable styling will be removed.
+   * If defined as a prop, this value will take higher precedence than the corresponding component design token value
    * Any valid [brand color token](/?path=/story/design-tokens-design-tokens--page#color) for the border color
    * Or a responsive prop with BrandColor for each breakpoint.
    */
   borderColor?: BrandColor;
   /**
-   * If defined as a prop, all themeable styling will be removed.
+   * If defined as a prop, this value will take higher precedence than the corresponding component design token value
    * Width of the section's border
    * Can be a single [border width token](/?path=/story/design-tokens-design-tokens--page#border-width).
    * Can also be a string of [border width tokens](/?path=/story/design-tokens-design-tokens--page#border-width)
@@ -72,12 +72,10 @@ export const CardSection: FC<CardSectionProps> = ({
     title
   );
 
-  const useTheme = background === undefined && borderColor === undefined && borderWidth === undefined;
-
   const sectionClasses = classNames(
     {
-      [styles['card-section']]: useTheme,
-      [styles.subdued]: useTheme && subdued,
+      [styles['card-section-border']]: borderColor === undefined && borderWidth === undefined,
+      [styles['card-subdued']]: subdued,
     },
     className,
   );

--- a/src/components/Card/components/CardSection/CardSection.tsx
+++ b/src/components/Card/components/CardSection/CardSection.tsx
@@ -7,7 +7,6 @@ import styles from '../../Card.module.scss';
 
 export interface CardSectionProps extends BoxProps {
   /**
-   * If defined as a prop, this value will take higher precedence than the corresponding component design token value
    * Any valid [brand color token](/?path=/story/design-tokens-design-tokens--page#color), or a `url()` for an image
    */
   background?: BrandColor;

--- a/src/components/Card/components/CardSection/CardSection.tsx
+++ b/src/components/Card/components/CardSection/CardSection.tsx
@@ -43,6 +43,10 @@ export interface CardSectionProps extends BoxProps {
    * Title for the section.
    */
   title?: ReactNode;
+  /**
+   * Additional props to be spread to rendered element
+   */
+  [x: string]: any; // eslint-disable-line
 }
 
 export const CardSection: FC<CardSectionProps> = ({

--- a/src/components/Card/components/CardSection/CardSection.tsx
+++ b/src/components/Card/components/CardSection/CardSection.tsx
@@ -2,20 +2,19 @@ import React, { FC, ReactNode } from 'react';
 import classNames from 'classnames';
 import { Box, BoxProps } from '../../../Box/Box';
 import { Heading } from '../../../Heading/Heading';
-import { BorderSize, BrandColor, ResponsiveProp } from '../../../../types';
 import styles from '../../Card.module.scss';
 
 export interface CardSectionProps extends BoxProps {
   /**
    * Any valid [brand color token](/?path=/story/design-tokens-design-tokens--page#color), or a `url()` for an image
    */
-  background?: BrandColor;
+  background?: BoxProps['background'];
   /**
    * If defined as a prop, this value will take higher precedence than the corresponding component design token value
    * Any valid [brand color token](/?path=/story/design-tokens-design-tokens--page#color) for the border color
    * Or a responsive prop with BrandColor for each breakpoint.
    */
-  borderColor?: BrandColor;
+  borderColor?: BoxProps['borderColor'];
   /**
    * If defined as a prop, this value will take higher precedence than the corresponding component design token value
    * Width of the section's border
@@ -25,7 +24,7 @@ export interface CardSectionProps extends BoxProps {
    * where you can set the border width on all four sides of an element.
    * e.g: "0 sm xs 0" --> top: 0, right: sm, bottom: xs, left: 0;
    */
-  borderWidth?: BorderSize | string | ResponsiveProp<BorderSize | string>;
+  borderWidth?: BoxProps['borderWidth'];
   /**
    * Contents of the Section.
    */


### PR DESCRIPTION
# Github Issue or Trello Card
This PR addresses this issue: https://trello.com/c/AeUi6Yvb/1209-card-if-a-box-prop-is-used-do-not-apply-the-card-classes

## Current State

With the recent implementation of component design tokens to enable theming, currently there is no way to allow for single-instance (or one-off) styling of a Card and it's child components. This is due to the fact that the classes applied by the Card.module.scss will always have a higher level of specificity than the utility classes that get applied via BoxProps.

## Solution

This pr makes it so that using any BoxProp whose css attribute matches the Card's will take precendent over the component design token's css attribute. This allows users of the component to use the default styles, use customize the appearance of their cards using the component design tokens, or have one-off styled versions of the Card using BoxProps.

Here's a screenshot of the documentation that illustrates this:

![Screen Shot 2022-03-22 at 3 41 23 PM](https://user-images.githubusercontent.com/1447339/159588243-0b026892-b903-4702-9302-3dd5fd55c8fc.png)

```jsx
// default appearance
<Card>
  <Card.Section>Default appearance</Card.Section>
  <Card.Section>Default appearance</Card.Section>
  <Card.Footer>footer</Card.Footer>
</Card>

// customized card theme
<Box
  childGap="xl"
  style={{
    '--card-background-color': 'var(--color-brand-tertiary-50)',
    '--card-footer-background-color': 'var(--color-brand-tertiary-900)',
    '--card-border-radius': 'var(--size-border-radius-lg)',
    '--card-section-border-color': 'var(--color-brand-tertiary-100)',
    '--card-box-shadow': '0',
  }}
>
// themed card instance
  <Card>
    <Card.Section>Themed card using component design tokens</Card.Section>
    <Card.Section>Themed card using component design tokens</Card.Section>
    <Card.Footer color="white">footer</Card.Footer>
  </Card>
// one-off styled card within a themed container
  <Card shadow="xl" radius="sm" background="secondary-50">
    <Card.Section>BoxProps are used instead of tokens</Card.Section>
    <Card.Section borderWidth="sm 0 0 0" borderColor="secondary-100">
      BoxProps are used instead of tokens
    </Card.Section>
    <Card.Footer background="secondary-900" color="grey-100">
      footer
    </Card.Footer>
  </Card>
</Box>
```

# What type of change is this?
Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Updating documentation.
- [ ] Updating deployment/build pipeline.
- [ ] Updating Project Dependencies
- [ ] Improving or adding to Test Coverage

# Completeness Checklist

- [ ] TESTS: My changes maintain the baseline required test coverage, as specified by code climate analysis.
- [ ] DOCS: All new component work is covered in that component's `Overview` docs.
- [ ] DOCS: All new component work is covered in a component `Playground`.
- [ ] DOCS: All new visual changes or options are covered under relevant components' `VisualTests`.
- [ ] My code has no linting or typescript compile warnings.
- [ ] My work is tied to a Github issue and satisfies the acceptance criteria (if applicable) of the corresponding issue.

# Quality Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

# UI Checklist
- [ ] I have conducted visual UAT on my changes/features.
- [ ] My solution works well on desktop, tablet, and mobile browsers.