### PR TITLE
fix(Button): remove custom button type

### DIFF
--- a/src/components/Button/Button.test.jsx
+++ b/src/components/Button/Button.test.jsx
@@ -5,12 +5,6 @@ import { BUTTON_SIZES, BUTTON_VARIANTS } from './Button.constants';
 
 describe('Button', () => {
   describe('Type', () => {
-    test('Sets the html button type to "button" by default', () => {
-      render(<Button>Default Button Type</Button>);
-
-      const testBtn = screen.getByText('Default Button Type').closest('button');
-      expect(testBtn.getAttribute('type')).toBe('button');
-    });
     test('Sets the html button type to "submit" if specified', () => {
       render(<Button type="submit">Submit Button</Button>);
 

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -86,12 +86,6 @@ export interface BaseButtonProps {
       */
      target?: AnchorHTMLAttributes<HTMLAnchorElement>['target'];
      /**
-      * The Button's type.
-      * NOTE: this is not restricted to button types since we allow
-      * rendering a button as a different HTML element than a button (`<a>` or `<input>`).
-      */
-     type?: 'submit' | 'reset' | 'button' | string;
-     /**
       * The size of the button.
       */
      size?: ButtonSize | ResponsiveProp<ButtonSize>;

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -127,7 +127,6 @@ export const Button = forwardRef<HTMLAnchorElement | HTMLButtonElement, ButtonPr
       onBlur = undefined,
       tabIndex = undefined,
       target = undefined,
-      type = 'button',
       size = 'md',
       variant = 'primary',
       ...restProps
@@ -229,7 +228,6 @@ export const Button = forwardRef<HTMLAnchorElement | HTMLButtonElement, ButtonPr
         (event: MouseEvent<HTMLAnchorElement | HTMLButtonElement>) => handleClick(event, onClick, target, navigate),
       onFocus: handleFocus,
       ref,
-      type: (href || as === 'a') ? null : type,
       tabIndex,
       ...restProps,
     }, buttonContent);


### PR DESCRIPTION
# Github Issue or Trello Card
This PR addresses this issue: Currently there is a conflict between the custom `type` prop in `BaseButtonProps` and the actual `type` attribute that comes from `ButtonHTMLAttributes`. Here I have removed the custom type prop so we only have the intrinsic attribute remaining.

# What type of change is this?
Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Updating documentation.
- [ ] Updating deployment/build pipeline.
- [ ] Updating Project Dependencies
- [ ] Improving or adding to Test Coverage

# Completeness Checklist

- [X] TESTS: My changes maintain the baseline required test coverage, as specified by code climate analysis.
- [X] DOCS: All new component work is covered in that component's `Overview` docs.
- [X] DOCS: All new component work is covered in a component `Playground`.
- [X] DOCS: All new visual changes or options are covered under relevant components' `VisualTests`.
- [X] My code has no linting or typescript compile warnings.
- [X] My work is tied to a Github issue and satisfies the acceptance criteria (if applicable) of the corresponding issue.

# Quality Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes

# UI Checklist
- [X] I have conducted visual UAT on my changes/features.
- [X] My solution works well on desktop, tablet, and mobile browsers.