### PR TITLE
fix(Button): default to button type if attribute not passed and is actual button

### DIFF
--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -99,10 +99,10 @@ export interface BaseButtonProps {
 }
 
 export type AnchorButtonProps = { as: 'a'; } &
-  BaseButtonProps & React.DetailedHTMLProps<AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>
+  BaseButtonProps & Omit<React.DetailedHTMLProps<AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>, 'ref'>
 
 export type NormalButtonProps = { as?: 'button'; } &
-  BaseButtonProps & React.DetailedHTMLProps<ButtonHTMLAttributes<HTMLButtonElement>, HTMLButtonElement>
+  BaseButtonProps & Omit<React.DetailedHTMLProps<ButtonHTMLAttributes<HTMLButtonElement>, HTMLButtonElement>, 'ref'>
 
 export type ButtonProps = NormalButtonProps | AnchorButtonProps
 

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -133,7 +133,7 @@ export const Button = forwardRef<HTMLAnchorElement | HTMLButtonElement, ButtonPr
       onBlur = undefined,
       tabIndex = undefined,
       target = undefined,
-      type = 'button',
+      type = undefined,
       size = 'md',
       variant = 'primary',
       ...restProps
@@ -235,7 +235,7 @@ export const Button = forwardRef<HTMLAnchorElement | HTMLButtonElement, ButtonPr
         (event: MouseEvent<HTMLAnchorElement | HTMLButtonElement>) => handleClick(event, onClick, target, navigate),
       onFocus: handleFocus,
       ref,
-      type: (href || as === 'a') ? null : type,
+      type: type ? type : (as !== 'a' && !href) && 'button',
       tabIndex,
       ...restProps,
     }, buttonContent);

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -130,7 +130,6 @@ export const Button = forwardRef<HTMLAnchorElement | HTMLButtonElement, ButtonPr
       type = undefined,
       size = 'md',
       variant = 'primary',
-      
       ...restProps
     },
     ref,
@@ -230,7 +229,7 @@ export const Button = forwardRef<HTMLAnchorElement | HTMLButtonElement, ButtonPr
         (event: MouseEvent<HTMLAnchorElement | HTMLButtonElement>) => handleClick(event, onClick, target, navigate),
       onFocus: handleFocus,
       ref,
-      type: type ? type : (as !== 'a' && !href) && 'button',
+      type: type || ((as !== 'a' && !href) && 'button'),
       tabIndex,
       ...restProps,
     }, buttonContent);

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -86,12 +86,6 @@ export interface BaseButtonProps {
       */
      target?: AnchorHTMLAttributes<HTMLAnchorElement>['target'];
      /**
-      * The Button's type.
-      * NOTE: this is not restricted to button types since we allow
-      * rendering a button as a different HTML element than a button (`<a>` or `<input>`).
-      */
-     type?: 'submit' | 'reset' | 'button' | string;
-     /**
       * The size of the button.
       */
      size?: ButtonSize | ResponsiveProp<ButtonSize>;
@@ -105,10 +99,10 @@ export interface BaseButtonProps {
 }
 
 export type AnchorButtonProps = { as: 'a'; } &
-  BaseButtonProps & React.HTMLAttributes<HTMLAnchorElement>
+  BaseButtonProps & React.DetailedHTMLProps<AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>
 
 export type NormalButtonProps = { as?: 'button'; } &
-  BaseButtonProps & ButtonHTMLAttributes<HTMLButtonElement>
+  BaseButtonProps & React.DetailedHTMLProps<ButtonHTMLAttributes<HTMLButtonElement>, HTMLButtonElement>
 
 export type ButtonProps = NormalButtonProps | AnchorButtonProps
 
@@ -136,6 +130,7 @@ export const Button = forwardRef<HTMLAnchorElement | HTMLButtonElement, ButtonPr
       type = undefined,
       size = 'md',
       variant = 'primary',
+      
       ...restProps
     },
     ref,


### PR DESCRIPTION
# Github Issue or Trello Card
This PR addresses this issue: With the removal of the type prop in the button, we had no proper default in place. This adds the type default once more which is semantically correct.

# What type of change is this?
Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Updating documentation.
- [ ] Updating deployment/build pipeline.
- [ ] Updating Project Dependencies
- [ ] Improving or adding to Test Coverage

# Completeness Checklist

- [X] TESTS: My changes maintain the baseline required test coverage, as specified by code climate analysis.
- [X] DOCS: All new component work is covered in that component's `Overview` docs.
- [X] DOCS: All new component work is covered in a component `Playground`.
- [X] DOCS: All new visual changes or options are covered under relevant components' `VisualTests`.
- [X] My code has no linting or typescript compile warnings.
- [X] My work is tied to a Github issue and satisfies the acceptance criteria (if applicable) of the corresponding issue.

# Quality Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes

# UI Checklist
- [X] I have conducted visual UAT on my changes/features.
- [X] My solution works well on desktop, tablet, and mobile browsers.