### PR TITLE
feat(MediaModal): add closeButton prop to render a visible close button

### DIFF
--- a/src/components/MediaModal/MediaModal.Overview.stories.mdx
+++ b/src/components/MediaModal/MediaModal.Overview.stories.mdx
@@ -97,6 +97,37 @@ An optional title and description can be used to describe the contents of the mo
   </Story>
 </Canvas>
 
+## Close Button
+
+Render a visible close button in the upper right of the viewport.
+
+<Canvas>
+  <Story name="With Close Button">
+    {() => {
+      const [showModal, setShowModal] = useState(false);
+      const open = () => setShowModal(true);
+      const close = () => setShowModal(false);
+      return (
+        <div>
+          <Button variant="light" onClick={open}>
+            Show with Close Button
+          </Button>
+          <MediaModal ariaLabel="landscape photo" isOpen={showModal} onDismiss={close} closeButton>
+            <img
+              src="images/landscape-mediamodal.jpg"
+              alt=""
+              style={{
+                objectFit: 'contain',
+                maxHeight: '100vh',
+              }}
+            />
+          </MediaModal>
+        </div>
+      );
+    }}
+  </Story>
+</Canvas>
+
 ## Custom Header and Footer
 
 A node can be passed to `headerContent` and `footerContent` for more control over what is displayed in the respective content areas of the MediaModal.

--- a/src/components/MediaModal/MediaModal.Playground.stories.tsx
+++ b/src/components/MediaModal/MediaModal.Playground.stories.tsx
@@ -1,14 +1,12 @@
 import React from 'react';
 import { Meta, Story } from '@storybook/react/types-6-0';
 import { MediaModal, MediaModalProps } from './MediaModal';
+import { Button } from '../Button/Button';
 
 export default {
   title: 'Components/MediaModal/Playground',
   component: MediaModal,
   argTypes: {
-    isOpen: {
-      control: 'boolean',
-    },
     title: {
       control: 'text',
     },
@@ -18,18 +16,30 @@ export default {
     footerContent: {
       control: 'text',
     },
+    closeButton: {
+      control: 'boolean',
+    },
   },
 } as Meta;
 
-const Template: Story<MediaModalProps> = ({ ...args }) => (
-  <MediaModal {...args}>
-    <img src="/images/landscape-mediamodal.jpg" alt="landscape test" />
-  </MediaModal>
-);
+const Template: Story<MediaModalProps> = ({ ...args }) => {
+  const [showModal, setShowModal] = React.useState(false);
+  const open = () => setShowModal(true);
+  const close = () => setShowModal(false);
+  return (
+    <>
+      <Button variant="light" onClick={open}>
+        Show MediaModal
+      </Button>
+      <MediaModal {...args} isOpen={showModal} onDismiss={close}>
+        <img src="/images/landscape-mediamodal.jpg" alt="landscape test" />
+      </MediaModal>
+    </>
+  );
+};
 
 export const Playground = Template.bind({});
 Playground.args = {
-  isOpen: false,
   title: 'title',
   description: 'description',
   footerContent: 'footer',

--- a/src/components/MediaModal/MediaModal.VisualTests.stories.tsx
+++ b/src/components/MediaModal/MediaModal.VisualTests.stories.tsx
@@ -23,6 +23,14 @@ LandscapeImage.args = {
   children: <img src="/images/landscape-mediamodal.jpg" alt="landscape test" />,
 };
 
+export const WithCloseButton = Template.bind({});
+WithCloseButton.args = {
+  ariaLabel: 'with close button MediaModal',
+  isOpen: true,
+  children: <img src="/images/landscape-mediamodal.jpg" alt="landscape test" />,
+  closeButton: true,
+};
+
 export const TitleDescriptionPortraitImage = Template.bind({});
 TitleDescriptionPortraitImage.args = {
   isOpen: true,

--- a/src/components/MediaModal/MediaModal.module.scss
+++ b/src/components/MediaModal/MediaModal.module.scss
@@ -41,8 +41,11 @@
     top: env(safe-area-inset-top, 0);
     right: env(safe-area-inset-right, 0);
     left: env(safe-area-inset-left, 0);
-    background: rgba(0, 0, 0, 0.5);
     color: var(--media-modal-font-color, var(--color-brand-grey-100));
+  }
+
+  .header-bar {
+    background: rgba(0, 0, 0, 0.5);
   }
 
   .title {

--- a/src/components/MediaModal/MediaModal.test.tsx
+++ b/src/components/MediaModal/MediaModal.test.tsx
@@ -10,6 +10,7 @@ const {
   PortraitImageFooter,
   TitleDescriptionPortraitImage,
   PortraitImageTitleDescriptionFooter,
+  WithCloseButton,
 } = composeStories(stories);
 
 describe('MediaModal', () => {
@@ -26,6 +27,11 @@ describe('MediaModal', () => {
   test('it uses the title as the dialog aria label', () => {
     const { getByLabelText } = render(<TitleDescriptionPortraitImage />);
     expect(getByLabelText('portrait-mediamodal.jpg')).toBeInTheDocument();
+  });
+
+  test('it renders a close button', () => {
+    const { getByLabelText } = render(<WithCloseButton />);
+    expect(getByLabelText('close')).toBeInTheDocument();
   });
 
   test('renders title and description', () => {

--- a/src/components/MediaModal/MediaModal.tsx
+++ b/src/components/MediaModal/MediaModal.tsx
@@ -32,6 +32,11 @@ export interface MediaModalProps {
    */
   containerRef?: React.RefObject<Node>;
   /**
+   * Whether the modal has a visible close button.
+   * If a title description, or headerContent is defined, then a close button will be rendered
+   */
+  closeButton?: boolean;
+  /**
    * By default the first focusable element will receive focus when the dialog
    * opens but you can provide a ref to focus instead.
    *
@@ -43,11 +48,14 @@ export interface MediaModalProps {
    */
   isOpen: boolean;
   /**
-   * Title to be displayed at the top of the viewport. If headerContent is defined, this will be ignored.
+   * Title to be displayed at the top of the viewport.
+   * A close button will be rendered automatically if this prop is defined.
+   * If headerContent is defined, this will be ignored.
    */
   title?: string;
   /**
    * Text to be displayed at the top of the viewport beneath the title.
+   * A close button will be rendered automatically if this prop is defined.
    * If headerContent is defined, this will be ignored.
    */
   description?: string;
@@ -57,6 +65,7 @@ export interface MediaModalProps {
   footerContent?: ReactNode;
   /**
    * Contents of the header area. If defined, the title and description will not be rendered.
+   * A close button will be rendered automatically if this prop is defined.
    */
   headerContent?: ReactNode;
   /**
@@ -78,6 +87,7 @@ export const MediaModal: React.FC<MediaModalProps> = forwardRef<HTMLDivElement, 
       description,
       children,
       className,
+      closeButton = false,
       containerRef = undefined,
       footerContent = undefined,
       headerContent = undefined,
@@ -91,7 +101,39 @@ export const MediaModal: React.FC<MediaModalProps> = forwardRef<HTMLDivElement, 
     const overlayClassnames = classNames(styles.overlay, styles['media-modal']);
     const contentClassnames = classNames(styles['media-modal'], className);
 
-    const showHeader = headerContent || title || description;
+    const showHeaderBar = headerContent || title || description;
+
+    const renderHeader = () => {
+      if (closeButton && !showHeaderBar) {
+        return (
+          <Box alignItems="flex-end" fontSize="lg" padding="lg" className={styles.header}>
+            <Button iconPrefix="remove-light" onClick={onDismiss} isNaked aria-label="close" />
+          </Box>
+        );
+      }
+      if (showHeaderBar) {
+        return (
+          <Box
+            direction="row"
+            justifyContent="space-between"
+            alignItems="center"
+            padding="md lg"
+            className={classNames(styles.header, styles['header-bar'])}
+          >
+            {headerContent || (
+              <Box childGap="2xs">
+                <Box className={styles.title}>{title}</Box>
+                <Box fontSize="xs">{description}</Box>
+              </Box>
+            )}
+            <Box fontSize="lg">
+              <Button iconPrefix="remove-light" onClick={onDismiss} isNaked aria-label="close" />
+            </Box>
+          </Box>
+        );
+      }
+      return null;
+    };
 
     return (
       <DialogOverlay
@@ -106,30 +148,7 @@ export const MediaModal: React.FC<MediaModalProps> = forwardRef<HTMLDivElement, 
       >
         <Box className={styles.container}>
           <DialogContent aria-label={ariaLabel || title} className={contentClassnames}>
-            {showHeader && (
-              <Box
-                direction="row"
-                justifyContent="space-between"
-                alignItems="center"
-                padding="md lg"
-                className={styles.header}
-              >
-                {headerContent || (
-                  <Box childGap="2xs">
-                    <Box className={styles.title}>{title}</Box>
-                    <Box fontSize="xs">{description}</Box>
-                  </Box>
-                )}
-                <Box fontSize="lg">
-                  <Button
-                    iconPrefix="remove-light"
-                    onClick={onDismiss}
-                    isNaked
-                    aria-label="close"
-                  />
-                </Box>
-              </Box>
-            )}
+            {renderHeader()}
             {children}
             {footerContent && <div className={styles.footer}>{footerContent}</div>}
           </DialogContent>


### PR DESCRIPTION
without requiring title, description or headerContent

# Github Issue or Trello Card
This PR addresses this issue: #748 

# What type of change is this?

Allows users to render a close button in the upper right of the viewport without defining `title`, `description`, or `headerContent` props.

![Screen Shot 2022-04-07 at 8 19 34 AM](https://user-images.githubusercontent.com/1447339/162234010-ef95c35a-a0cb-4d42-84d3-445f7d6094ff.png)

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Updating documentation.
- [ ] Updating deployment/build pipeline.
- [ ] Updating Project Dependencies
- [ ] Improving or adding to Test Coverage

# Completeness Checklist

- [x] TESTS: My changes maintain the baseline required test coverage, as specified by code climate analysis.
- [x] DOCS: All new component work is covered in that component's `Overview` docs.
- [x] DOCS: All new component work is covered in a component `Playground`.
- [x] DOCS: All new visual changes or options are covered under relevant components' `VisualTests`.
- [x] My code has no linting or typescript compile warnings.
- [x] My work is tied to a Github issue and satisfies the acceptance criteria (if applicable) of the corresponding issue.

# Quality Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

# UI Checklist
- [ ] I have conducted visual UAT on my changes/features.
- [ ] My solution works well on desktop, tablet, and mobile browsers.