### PR TITLE
fix(Modal): style focus state for close button

### DIFF
--- a/src/components/Modal/Modal.Overview.stories.mdx
+++ b/src/components/Modal/Modal.Overview.stories.mdx
@@ -238,6 +238,7 @@ maxWidth, use existing tokens only.
         '--modal-box-shadow': '--size-box-shadow-md',
         '--modal-close-button-color': '--color-brand-grey-500',
         '--modal-close-button-color-hover': '--color-brand-grey-600',
+        '--modal-close-button-box-shadow-focus': '--color-brand-grey-200',
       };
       return Object.entries(tokens).map(([name, entry], i) => (
         <tr key={i}>

--- a/src/components/Modal/Modal.module.scss
+++ b/src/components/Modal/Modal.module.scss
@@ -16,8 +16,8 @@
     color: var(--modal-close-button-color-hover, var(--color-brand-grey-600));
   }
 
-   /* Show focus styles on keyboard focus. */
-   &:focus-visible {
+  /* Show focus styles on keyboard focus. */
+  &:focus-visible {
     outline: 0;
     box-shadow: var(--modal-close-button-box-shadow-focus, 0 0 0 4px var(--color-brand-grey-200));
   }

--- a/src/components/Modal/Modal.module.scss
+++ b/src/components/Modal/Modal.module.scss
@@ -9,10 +9,26 @@
   cursor: pointer;
   padding: var(--size-spacing-xs);
   color: var(--modal-close-button-color, var(--color-brand-grey-500));
+  line-height: var(--size-line-height-base);
+  border-radius: var(--size-border-radius-sm);
 
   &:hover {
     color: var(--modal-close-button-color-hover, var(--color-brand-grey-600));
   }
+
+   /* Show focus styles on keyboard focus. */
+   &:focus-visible {
+    outline: 0;
+    box-shadow: var(--modal-close-button-box-shadow-focus, 0 0 0 4px var(--color-brand-grey-200));
+  }
+
+  /* Hide focus styles if they're not needed, for example,
+  when an element receives focus via the mouse. */
+  &:focus:not(:focus-visible) {
+    outline: 0;
+    box-shadow: none;
+  }
+
 }
 
 [data-reach-dialog-overlay].modal {


### PR DESCRIPTION
# Github Issue or Trello Card
This PR addresses this issue: #727 

Adds deliberate styles to the focus state of a Modal's close button

# What type of change is this?
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Updating documentation.
- [ ] Updating deployment/build pipeline.
- [ ] Updating Project Dependencies
- [ ] Improving or adding to Test Coverage

# Completeness Checklist

- [x] TESTS: My changes maintain the baseline required test coverage, as specified by code climate analysis.
- [ ] DOCS: All new component work is covered in that component's `Overview` docs.
- [ ] DOCS: All new component work is covered in a component `Playground`.
- [x] DOCS: All new visual changes or options are covered under relevant components' `VisualTests`.
- [x] My code has no linting or typescript compile warnings.
- [x] My work is tied to a Github issue and satisfies the acceptance criteria (if applicable) of the corresponding issue.

# Quality Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

# UI Checklist
- [ ] I have conducted visual UAT on my changes/features.
- [ ] My solution works well on desktop, tablet, and mobile browsers.