### PR TITLE
fix: add explicity permission keys for release action

### DIFF
--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -5,6 +5,9 @@ on:
 jobs:
   publish-new-package:
     runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      contents: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2


### PR DESCRIPTION
# Github Issue or Trello Card
This PR addresses this issue: Release action can no longer push to the repo.

# What type of change is this?
Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Updating documentation.
- [ ] Updating deployment/build pipeline.
- [ ] Updating Project Dependencies
- [ ] Improving or adding to Test Coverage

# Completeness Checklist

- [X] TESTS: My changes maintain the baseline required test coverage, as specified by code climate analysis.
- [X] DOCS: All new component work is covered in that component's `Overview` docs.
- [X] DOCS: All new component work is covered in a component `Playground`.
- [X] DOCS: All new visual changes or options are covered under relevant components' `VisualTests`.
- [X] My code has no linting or typescript compile warnings.
- [X] My work is tied to a Github issue and satisfies the acceptance criteria (if applicable) of the corresponding issue.

# Quality Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes

# UI Checklist
- [X] I have conducted visual UAT on my changes/features.
- [X] My solution works well on desktop, tablet, and mobile browsers.