### PR TITLE
fix(Button): html type property getting set to boolean value

### DIFF
--- a/src/components/Button/Button.test.jsx
+++ b/src/components/Button/Button.test.jsx
@@ -26,7 +26,7 @@ describe('Button', () => {
       expect(testBtn.getAttribute('type')).toBe('reset');
     });
 
-    test('is set to not set if as is not a button', () => {
+    test('is not set if "as" prop anchor tag', () => {
       render(
         <Button as="a" href="https://www.palmetto.com">
           link button

--- a/src/components/Button/Button.test.jsx
+++ b/src/components/Button/Button.test.jsx
@@ -6,16 +6,34 @@ import { BUTTON_SIZES, BUTTON_VARIANTS } from './Button.constants';
 describe('Button', () => {
   describe('Type', () => {
     test('Sets the html button type to "submit" if specified', () => {
+  describe('html button type', () => {
+    test('is set to button', () => {
+      render(<Button>Button</Button>);
+      const testBtn = screen.getByRole('button');
+      expect(testBtn.getAttribute('type')).toBe('button');
+    });
+    test('is set to "submit" if specified', () => {
       render(<Button type="submit">Submit Button</Button>);
 
-      const testBtn = screen.getByText('Submit Button').closest('button');
+      const testBtn = screen.getByRole('button');
       expect(testBtn.getAttribute('type')).toBe('submit');
     });
     test('Sets the html button type to "reset" if specified', () => {
+    test('is set to "reset" if specified', () => {
       render(<Button type="reset">Reset Button</Button>);
 
-      const testBtn = screen.getByText('Reset Button').closest('button');
+      const testBtn = screen.getByRole('button');
       expect(testBtn.getAttribute('type')).toBe('reset');
+    });
+
+    test('is set to not set if as is not a button', () => {
+      render(
+        <Button as="a" href="https://www.palmetto.com">
+          link button
+        </Button>,
+      );
+      const testBtn = screen.getByText('link button').parentElement;
+      expect(testBtn).not.toHaveAttribute('type');
     });
   });
 

--- a/src/components/Button/Button.test.jsx
+++ b/src/components/Button/Button.test.jsx
@@ -4,21 +4,20 @@ import { Button } from './Button';
 import { BUTTON_SIZES, BUTTON_VARIANTS } from './Button.constants';
 
 describe('Button', () => {
-  describe('Type', () => {
-    test('Sets the html button type to "submit" if specified', () => {
   describe('html button type', () => {
     test('is set to button', () => {
       render(<Button>Button</Button>);
       const testBtn = screen.getByRole('button');
       expect(testBtn.getAttribute('type')).toBe('button');
     });
+
     test('is set to "submit" if specified', () => {
       render(<Button type="submit">Submit Button</Button>);
 
       const testBtn = screen.getByRole('button');
       expect(testBtn.getAttribute('type')).toBe('submit');
     });
-    test('Sets the html button type to "reset" if specified', () => {
+
     test('is set to "reset" if specified', () => {
       render(<Button type="reset">Reset Button</Button>);
 
@@ -26,7 +25,7 @@ describe('Button', () => {
       expect(testBtn.getAttribute('type')).toBe('reset');
     });
 
-    test('is not set if "as" prop anchor tag', () => {
+    test('is not set if "as" prop is an anchor tag', () => {
       render(
         <Button as="a" href="https://www.palmetto.com">
           link button

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -229,7 +229,7 @@ export const Button = forwardRef<HTMLAnchorElement | HTMLButtonElement, ButtonPr
         (event: MouseEvent<HTMLAnchorElement | HTMLButtonElement>) => handleClick(event, onClick, target, navigate),
       onFocus: handleFocus,
       ref,
-      type: type || ((as !== 'a' && !href) && 'button'),
+      type: type || ((as !== 'a' && !href) ? 'button' : undefined),
       tabIndex,
       ...restProps,
     }, buttonContent);


### PR DESCRIPTION
# Github Issue or Trello Card
This PR addresses this issue: #769 

Stops this console warning from appearing while running locally. 
![Screen Shot 2022-05-11 at 5 44 21 PM](https://user-images.githubusercontent.com/1447339/167969893-2afc1601-d148-4e73-8ebd-d97ce1901622.png)



# What type of change is this?
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Completeness Checklist

- [x] TESTS: My changes maintain the baseline required test coverage, as specified by code climate analysis.
- [ ] DOCS: All new component work is covered in that component's `Overview` docs.
- [ ] DOCS: All new component work is covered in a component `Playground`.
- [ ] DOCS: All new visual changes or options are covered under relevant components' `VisualTests`.
- [x] My code has no linting or typescript compile warnings.
- [x] My work is tied to a Github issue and satisfies the acceptance criteria (if applicable) of the corresponding issue.

# Quality Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

# UI Checklist
- [x] I have conducted visual UAT on my changes/features.
- [x] My solution works well on desktop, tablet, and mobile browsers.