### PR TITLE
fix: OptionTile, SelectInput, SelectInputNative, TextareaInput focus states

### DIFF
--- a/src/components/OptionTile/OptionTile.VisualTests.stories.tsx
+++ b/src/components/OptionTile/OptionTile.VisualTests.stories.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Meta, Story } from '@storybook/react/types-6-0';
+import { within } from '@storybook/testing-library';
 import { OptionTile, OptionTileProps } from './OptionTile';
 
 export default {
@@ -64,4 +65,34 @@ HiddenInput.args = {
   hideInput: true,
   value: 'hiddenInput',
   label: 'hiddenInput',
+};
+
+export const FocusUnchecked = Template.bind({});
+FocusUnchecked.args = {
+  isSelected: false,
+  children: 'radio unchecked',
+  id: 'radioUnchecked',
+  name: 'radioUnchecked',
+  value: 'radioUnchecked',
+  label: 'radioUnchecked',
+};
+
+FocusUnchecked.play = async ({ canvasElement }) => {
+  const canvas = within(canvasElement);
+  canvas.getByRole('radio').focus();
+};
+
+export const FocusChecked = Template.bind({});
+FocusChecked.args = {
+  isSelected: true,
+  children: 'radio selected',
+  id: 'radioSelected',
+  name: 'radioSelected',
+  value: 'radioSelected',
+  label: 'radioSelected',
+};
+
+FocusChecked.play = async ({ canvasElement }) => {
+  const canvas = within(canvasElement);
+  canvas.getByRole('radio').focus();
 };

--- a/src/components/OptionTile/OptionTile.module.scss
+++ b/src/components/OptionTile/OptionTile.module.scss
@@ -4,6 +4,11 @@
   border-radius: var(--option-tile-border-radius, var(--form-control-size-md-border-radius, var(--INTERNAL_form-control-size-md-border-radius)));
   font-family: var(--option-tile-font-family, var(--form-control-font-family, var(--INTERNAL_form-control-font-family)));
 
+  &:focus-within {
+    box-shadow: var(--form-control-box-shadow-focus, var(--INTERNAL_form-control-box-shadow-focus)),
+      inset 0 0 0 1px var(--form-control-border-color-focus, var(--INTERNAL_form-control-border-color-focus));
+  }
+  
   &:hover {
     border: 1px solid var(--option-tile-border-color-hover, var(--form-control-border-color-hover, var(--INTERNAL_form-control-border-color-hover)));
   }

--- a/src/components/SelectInput/SelectInput.module.scss
+++ b/src/components/SelectInput/SelectInput.module.scss
@@ -175,7 +175,8 @@ react-select elements for which we do not own the markup */
 
       &:global(.react-select__control--is-focused) {
         border-color: var(--form-control-border-color-focus, var(--INTERNAL_form-control-border-color-focus));
-        box-shadow: none;
+        box-shadow: var(--form-control-box-shadow, var(--INTERNAL_form-control-box-shadow-focus)),
+        inset 0 0 0 1px var(--form-control-border-color-focus, var(--INTERNAL_form-control-border-color-focus));
       }
 
       &:global(.react-select__control--is-disabled) {

--- a/src/components/SelectInputNative/SelectInputNative.module.scss
+++ b/src/components/SelectInputNative/SelectInputNative.module.scss
@@ -132,7 +132,7 @@
 
   &:focus-within {
     outline: none;
-    box-shadow: var(--form-control-box-shadow, var(--INTERNAL_form-control-box-shadow)),
+    box-shadow: var(--form-control-box-shadow, var(--INTERNAL_form-control-box-shadow-focus)),
       inset 0 0 0 1px var(--form-control-border-color-focus, var(--INTERNAL_form-control-border-color-focus));
   }
 

--- a/src/components/TextareaInput/TextareaInput.module.scss
+++ b/src/components/TextareaInput/TextareaInput.module.scss
@@ -153,11 +153,21 @@
       background-color: var(--form-control-border-color-focus, var(--INTERNAL_form-control-background-color-error));
     }
 
-    &:focus {
+    textarea:focus {
       outline: none;
-      border-color: var(--form-control-border-color-focus, var(--INTERNAL_form-control-border-color-focus));
-      background-color: var(--form-control-background-color, var(--INTERNAL_form-control-background-color));
+      background-color: transparent;
     }
+
+    &:focus-within {
+      background-color: var(--form-control-background-color, var(--INTERNAL_form-control-background-color));
+      border-color: var(--form-control-border-color-focus, var(--INTERNAL_form-control-border-color-focus));
+    }
+  }
+
+  &:focus-within {
+    outline: none;
+    box-shadow: var(--form-control-box-shadow-focus, var(--INTERNAL_form-control-box-shadow-focus)),
+      inset 0 0 0 1px var(--form-control-border-color-focus, var(--INTERNAL_form-control-border-color-focus));
   }
 }
 


### PR DESCRIPTION
Adds visible focus states to OptionTile, SelectInput, SelectInputNative and TextareaInput components. Also adds chromatic snapshots if they didn't already exist to cover focus states.

# What type of change is this?
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Completeness Checklist

- [x] TESTS: My changes maintain the baseline required test coverage, as specified by code climate analysis.
- [ ] DOCS: All new component work is covered in that component's `Overview` docs.
- [ ] DOCS: All new component work is covered in a component `Playground`.
- [ ] DOCS: All new visual changes or options are covered under relevant components' `VisualTests`.
- [x] My code has no linting or typescript compile warnings.
- [ ] My work is tied to a Github issue and satisfies the acceptance criteria (if applicable) of the corresponding issue.

# Quality Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

# UI Checklist
- [x] I have conducted visual UAT on my changes/features.
- [x] My solution works well on desktop, tablet, and mobile browsers.