### PR TITLE
feat: add support for table cell class names to be generated via a function

### DIFF
--- a/src/components/Table/Table.Overview.stories.mdx
+++ b/src/components/Table/Table.Overview.stories.mdx
@@ -44,7 +44,7 @@ NOTE: all properties in a column object are optional, but we highly recommend in
         },
         {
           name: 'cellClassName',
-          type: 'string',
+          type: 'string | (function: (cell, row, rowIndex) => string)',
           description: 'A CSS class to be applied to all cells in the column',
         },
         {

--- a/src/components/Table/common/TableRow/TableRow.test.tsx
+++ b/src/components/Table/common/TableRow/TableRow.test.tsx
@@ -24,5 +24,37 @@ describe('TableRow', () => {
       const tableRow = screen.getByRole('row');
       expect(tableRow).toHaveClass('my-custom-class');
     });
+
+    test('It renders with a custom cell class (function) is passed as prop', () => {
+      const func = jest.fn().mockReturnValue('my-custom-class');
+      const customClassCell = [
+        { heading: 'ID', dataKey: 'id', cellClassName: func },
+      ];
+      render(
+        <TableRow
+          row={row}
+          rowIndex={rowIndex}
+          columns={customClassCell}
+        />,
+      );
+      expect(func).toHaveBeenCalledWith(customClassCell[0], row, rowIndex);
+      const element = document.getElementsByClassName('my-custom-class')[0];
+      expect(element).toBeInTheDocument();
+    });
+
+    test('It renders with a custom cell class (string) is passed as prop', () => {
+      const customClassCell = [
+        { heading: 'ID', dataKey: 'id', cellClassName: 'string-class' },
+      ];
+      render(
+        <TableRow
+          row={row}
+          rowIndex={rowIndex}
+          columns={customClassCell}
+        />,
+      );
+      const element = document.getElementsByClassName('string-class')[0];
+      expect(element).toBeInTheDocument();
+    });
   });
 });

--- a/src/components/Table/common/TableRow/TableRow.tsx
+++ b/src/components/Table/common/TableRow/TableRow.tsx
@@ -102,6 +102,16 @@ export const TableRow: FC<TableRowProps> = ({
     return column.dataKey && row ? row[column.dataKey] : null;
   };
 
+  const getCellClassName = (column: Column):string|undefined => {
+    if (column.cellClassName) {
+      if (typeof column.cellClassName === 'function') {
+        return column.cellClassName(column, row, rowIndex);
+      }
+      return column.cellClassName;
+    }
+    return undefined;
+  };
+
   return (
     <tr className={tableRowClasses}>
       {Object.values(columns).map((column, columnIndex) => (
@@ -125,7 +135,7 @@ export const TableRow: FC<TableRowProps> = ({
         ) : (
           <TableBodyCell
             align={column.align || align}
-            className={column.cellClassName}
+            className={getCellClassName(column)}
             emptyCellPlaceholder={column.emptyCellPlaceholder || emptyCellPlaceholder}
             truncateOverflow={column.truncateOverflow || truncateOverflow}
             key={getColumnKeys(columns)[columnIndex]}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -145,7 +145,7 @@ export declare type Column = {
   /**
    * CSS Class to be applied uniformly to all individual cells in a column.
    */
-  cellClassName?: string;
+  cellClassName?: string | ((cell?: Cell, row?: Row, rowIndex?: number) => string);
   /**
    * The key value to be rendered based on the table `rows`.
    */


### PR DESCRIPTION
Allow cellClassName to be a function and pass the same data as render so that consumers can use that data to choose a class.

# Github Issue or Trello Card
This PR addresses this issue: 

# What type of change is this?
Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Updating documentation.
- [ ] Updating deployment/build pipeline.
- [ ] Updating Project Dependencies
- [ ] Improving or adding to Test Coverage

# Completeness Checklist

- [x] TESTS: My changes maintain the baseline required test coverage, as specified by code climate analysis.
- [x] DOCS: All new component work is covered in that component's `Overview` docs.
- [x] DOCS: All new component work is covered in a component `Playground`.
- [x] DOCS: All new visual changes or options are covered under relevant components' `VisualTests`.
- [ x My code has no linting or typescript compile warnings.
- [x] My work is tied to a Github issue and satisfies the acceptance criteria (if applicable) of the corresponding issue.

# Quality Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

# UI Checklist
- [ ] I have conducted visual UAT on my changes/features.
- [ ] My solution works well on desktop, tablet, and mobile browsers.