### PR TITLE
fix(Table): apply bg color to Table rather then cells

### DIFF
--- a/src/components/Table/Table.Overview.stories.mdx
+++ b/src/components/Table/Table.Overview.stories.mdx
@@ -1082,25 +1082,6 @@ You can use a ReactNode as your table header or cell.
           '--table-row-striped-background': 'var(--color-brand-grey-800)',
         }}>
           <Table rowKey="id" columns={columnConfig} rows={tableData} isStriped />
-        <div
-          style={{
-            '--table-border-color': 'var(--color-brand-grey-700)',
-            '--table-border-width': 'var(--size-border-md)',
-            '--table-background-color': 'var(--color-brand-grey-900)',
-            '--table-header-background-color': 'var(--color-brand-grey-900)',
-            '--table-font-color': 'var(--color-brand-grey-100)',
-            '--table-header-font-color': 'var(--color-brand-grey-100)',
-            '--table-header-font-size': 'var(--size-font-lg)',
-            '--table-font-size': 'var(--size-font-md)',
-            '--table-row-striped-background': 'var(--color-brand-grey-800)',
-          }}
-        >
-          <Table
-            rowKey="id"
-            columns={columnConfig}
-            rows={tableData}
-            isStriped
-          />
         </div>
       );
     }}
@@ -1112,7 +1093,7 @@ You can use a ReactNode as your table header or cell.
 Add custom classes to cells in a column by passing the `cellClassName` in the column config.
 
 <Canvas>
-  <Story name="Custom Column Classes">
+  <Story name="Custom Cell Classes">
     {() => {
       const columnConfig = [
         {
@@ -1136,6 +1117,8 @@ Add custom classes to cells in a column by passing the `cellClassName` in the co
     }}
   </Story>
 </Canvas>
+
+
 ## Component Design Tokens
 
 <table>

--- a/src/components/Table/Table.Overview.stories.mdx
+++ b/src/components/Table/Table.Overview.stories.mdx
@@ -1082,12 +1082,60 @@ You can use a ReactNode as your table header or cell.
           '--table-row-striped-background': 'var(--color-brand-grey-800)',
         }}>
           <Table rowKey="id" columns={columnConfig} rows={tableData} isStriped />
+        <div
+          style={{
+            '--table-border-color': 'var(--color-brand-grey-700)',
+            '--table-border-width': 'var(--size-border-md)',
+            '--table-background-color': 'var(--color-brand-grey-900)',
+            '--table-header-background-color': 'var(--color-brand-grey-900)',
+            '--table-font-color': 'var(--color-brand-grey-100)',
+            '--table-header-font-color': 'var(--color-brand-grey-100)',
+            '--table-header-font-size': 'var(--size-font-lg)',
+            '--table-font-size': 'var(--size-font-md)',
+            '--table-row-striped-background': 'var(--color-brand-grey-800)',
+          }}
+        >
+          <Table
+            rowKey="id"
+            columns={columnConfig}
+            rows={tableData}
+            isStriped
+          />
         </div>
       );
     }}
   </Story>
 </Canvas>
 
+## Custom Column Classes
+
+Add custom classes to cells in a column by passing the `cellClassName` in the column config.
+
+<Canvas>
+  <Story name="Custom Column Classes">
+    {() => {
+      const columnConfig = [
+        {
+          heading: 'with cellClassName',
+          dataKey: 'id',
+          cellClassName:
+            'background-color-secondary-lightest',
+        },
+        {
+          heading: 'With headerClassName',
+          dataKey: 'color',
+        },
+        { heading: 'Flavor', dataKey: 'flavor' },
+      ];
+      const tableData = [
+        { id: 1, color: 'red', flavor: 'vanilla' },
+        { id: 2, color: 'blue', flavor: 'chocolate' },
+        { id: 3, color: 'green', flavor: 'strawberry' },
+      ];
+      return <Table rowKey="id" columns={columnConfig} rows={tableData} />;
+    }}
+  </Story>
+</Canvas>
 ## Component Design Tokens
 
 <table>

--- a/src/components/Table/Table.module.scss
+++ b/src/components/Table/Table.module.scss
@@ -15,6 +15,7 @@
 
   .scroll-container {
     .table {
+      background-color: var(--table-background-color, var(--INTERNAL_table-background-color));
       margin-top: 1px;
       cursor: default;
       width: 100%;

--- a/src/components/Table/TableBody/TableBodyCell/TableBodyCell.module.scss
+++ b/src/components/Table/TableBody/TableBodyCell/TableBodyCell.module.scss
@@ -22,18 +22,21 @@
     white-space: nowrap;
   }
 
-  &.sticky-column {
-    position: sticky;
-    z-index: calc(var(--size-z-index-sticky) - 1);
-    box-shadow: var(--size-box-shadow-md);
-  }
-
   &.sticky-column-left {
+    background-color: var(--table-background-color, var(--INTERNAL_table-background-color));
     left: 0;
   }
 
   &.sticky-column-right {
+    background-color: var(--table-background-color, var(--INTERNAL_table-background-color));
     right: 0;
+  }
+
+  &.sticky-column {
+    position: sticky;
+    z-index: calc(var(--size-z-index-sticky) - 1);
+    background-color: var(--table-background-color, var(--INTERNAL_table-background-color));
+    box-shadow: 5px 0px 5px -2px rgba(0,0,0,0.1), -5px 0px 5px -2px rgba(0,0,0,0.1);
   }
 
   &.align-right {

--- a/src/components/Table/TableBody/TableBodyCell/TableBodyCell.module.scss
+++ b/src/components/Table/TableBody/TableBodyCell/TableBodyCell.module.scss
@@ -1,5 +1,4 @@
 .table-cell {
-  background-color: var(--table-background-color, var(--INTERNAL_table-background-color));
   border-color: var(--table-border-color, var(--INTERNAL_table-border-color));
   border-bottom-style: solid;
   border-width: 0 0 var(--table-header-border-width, var(--INTERNAL_table-header-border-width)) 0;

--- a/src/components/Table/TableBody/TableBodyCell/TableBodyCell.module.scss
+++ b/src/components/Table/TableBody/TableBodyCell/TableBodyCell.module.scss
@@ -36,7 +36,7 @@
     position: sticky;
     z-index: calc(var(--size-z-index-sticky) - 1);
     background-color: var(--table-background-color, var(--INTERNAL_table-background-color));
-    box-shadow: 5px 05px -2px rgba(0, 0, 0, 0.1), -5px 0 5px -2px rgba(0, 0, 0, 0.1);
+    box-shadow: 5px 0 5px -2px rgba(0, 0, 0, 0.1), -5px 0 5px -2px rgba(0, 0, 0, 0.1);
   }
 
   &.align-right {

--- a/src/components/Table/TableBody/TableBodyCell/TableBodyCell.module.scss
+++ b/src/components/Table/TableBody/TableBodyCell/TableBodyCell.module.scss
@@ -36,7 +36,7 @@
     position: sticky;
     z-index: calc(var(--size-z-index-sticky) - 1);
     background-color: var(--table-background-color, var(--INTERNAL_table-background-color));
-    box-shadow: 5px 0px 5px -2px rgba(0,0,0,0.1), -5px 0px 5px -2px rgba(0,0,0,0.1);
+    box-shadow: 5px 05px -2px rgba(0, 0, 0, 0.1), -5px 0 5px -2px rgba(0, 0, 0, 0.1);
   }
 
   &.align-right {

--- a/src/components/Table/TableHead/TableHeaderCell/TableHeaderCell.module.scss
+++ b/src/components/Table/TableHead/TableHeaderCell/TableHeaderCell.module.scss
@@ -50,7 +50,7 @@
   &.sticky-column {
     position: sticky;
     z-index: calc(var(--size-z-index-sticky) + 1);
-    box-shadow: 5px 0px 5px -2px rgba(0,0,0,0.1), -5px 0px 5px -2px rgba(0,0,0,0.1);
+    box-shadow: 5px 0 5px -2px rgba(0, 0, 0, 0.1), -5px 0 5px -2px rgba(0, 0, 0, 0.1);
     background-color: var(--table-header-background-color, var(--INTERNAL_table-header-background-color));
   }
 

--- a/src/components/Table/TableHead/TableHeaderCell/TableHeaderCell.module.scss
+++ b/src/components/Table/TableHead/TableHeaderCell/TableHeaderCell.module.scss
@@ -38,12 +38,6 @@
     z-index: var(--size-z-index-sticky);
   }
 
-  &.sticky-column {
-    position: sticky;
-    z-index: calc(var(--size-z-index-sticky) + 1);
-    box-shadow: 2px 0 0 0 rgba(0, 0, 0, 0.05), 1px 0 0 0 rgba(0, 0, 0, 0.05), -2px 0 0 0 rgba(0, 0, 0, 0.05), -1px 0 0 0 rgba(0, 0, 0, 0.05);
-    background-color: var(--table-header-background-color, var(--INTERNAL_table-header-background-color));
-  }
 
   &.sticky-column-left {
     left: 0;
@@ -52,6 +46,14 @@
   &.sticky-column-right {
     right: 0;
   }
+
+  &.sticky-column {
+    position: sticky;
+    z-index: calc(var(--size-z-index-sticky) + 1);
+    box-shadow: 5px 0px 5px -2px rgba(0,0,0,0.1), -5px 0px 5px -2px rgba(0,0,0,0.1);
+    background-color: var(--table-header-background-color, var(--INTERNAL_table-header-background-color));
+  }
+
 
   &.align-right {
     text-align: right;


### PR DESCRIPTION
# Github Issue or Trello Card
This PR addresses this issue: https://palmetto-team.slack.com/archives/C014E879QCX/p1655163348578379

Moves the background color specificity to the `Table` rather then to each `cell`. This allows consumers to customize the styling of table rows and cells via other means.

# What type of change is this?
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


# Completeness Checklist

- [ ] TESTS: My changes maintain the baseline required test coverage, as specified by code climate analysis.
- [ ] DOCS: All new component work is covered in that component's `Overview` docs.
- [ ] DOCS: All new component work is covered in a component `Playground`.
- [ ] DOCS: All new visual changes or options are covered under relevant components' `VisualTests`.
- [ ] My code has no linting or typescript compile warnings.
- [ ] My work is tied to a Github issue and satisfies the acceptance criteria (if applicable) of the corresponding issue.

# Quality Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

# UI Checklist
- [ ] I have conducted visual UAT on my changes/features.
- [ ] My solution works well on desktop, tablet, and mobile browsers.