### PR TITLE
chore: publish to GitHub Packages

### DIFF
--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -8,6 +8,8 @@ jobs:
     permissions:
       actions: write
       contents: write
+      packages: write
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -36,3 +38,12 @@ jobs:
         run: yarn deploy-storybook --ci
         env:
           GH_TOKEN: palmetto:${{ secrets.GITHUB_TOKEN }}
+      - name: Setup Node
+        uses: actions/setup-node@v2
+        with:
+          node-version: '14'
+          registry-url: https://npm.pkg.github.com/
+      - name: Release to GitHub Packages
+        env:
+          NPM_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: yarn semantic-release


### PR DESCRIPTION
Publish to [GitHub Packages](https://github.com/features/packages) in addition to NPM, so that we can publish private packages in GitHub Packages and use them alongside palmetto-components.

Context: 

- https://github.community/t/github-package-registry-with-private-packages-proxying-scope-to-npm/2782
- https://sevic.dev/npm-publish-github-actions/

# What type of change is this?

- [x] Updating deployment/build pipeline.
