### PR TITLE
fix(Drawer): prevent top/bottom placement drawers from being taller then viewport

### DIFF
--- a/src/components/Drawer/Drawer.VisualTests.stories.tsx
+++ b/src/components/Drawer/Drawer.VisualTests.stories.tsx
@@ -7,7 +7,11 @@ export default {
   title: 'Components/Drawer/Visual Regression Tests',
   component: Drawer,
   parameters: {
-    chromatic: { delay: 1000, pauseAnimationAtEnd: true, viewports: [350, 700, 1012, 1300] },
+    chromatic: {
+      delay: 1000,
+      pauseAnimationAtEnd: true,
+      viewports: [350, 700, 1012, 1300],
+    },
   },
 };
 
@@ -176,6 +180,13 @@ LeftDrawerHideOverlayTokenWidth.args = {
 export const TopDrawer = Template.bind({});
 TopDrawer.args = {
   ariaLabel: 'Top Drawer',
+  isOpen: true,
+  placement: 'top',
+};
+
+export const TopDrawerScroll = LongContentTemplate.bind({});
+TopDrawerScroll.args = {
+  ariaLabel: 'Top Drawer Scrolling',
   isOpen: true,
   placement: 'top',
 };

--- a/src/components/Drawer/Drawer.module.scss
+++ b/src/components/Drawer/Drawer.module.scss
@@ -70,6 +70,7 @@
     &.bottom {
       bottom: 0;
       width: 100%;
+      max-height: 100vh;
 
       :global {
         animation: fadeInUp 0.2s ease-out;
@@ -79,6 +80,7 @@
     &.top {
       top: 0;
       width: 100%;
+      max-height: 100vh;
 
       :global {
         animation: fadeInDown 0.2s ease-out;


### PR DESCRIPTION
Currently, if the content of a Drawer is taller than the viewport height on Drawers with placement set to `top` or `bottom`, the Drawer height grows, which has the side effect of not allowing the drawer content to scroll. 

This sets a max-height for top and bottom placed Drawers so that it's contents will be scrollable.

# Github Issue or Trello Card
This PR addresses this issue: 

# What type of change is this?
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Updating documentation.
- [ ] Updating deployment/build pipeline.
- [ ] Updating Project Dependencies
- [ ] Improving or adding to Test Coverage

# Completeness Checklist

- [x] TESTS: My changes maintain the baseline required test coverage, as specified by code climate analysis.
- [ ] DOCS: All new component work is covered in that component's `Overview` docs.
- [ ] DOCS: All new component work is covered in a component `Playground`.
- [ ] DOCS: All new visual changes or options are covered under relevant components' `VisualTests`.
- [ ] My code has no linting or typescript compile warnings.
- [ ] My work is tied to a Github issue and satisfies the acceptance criteria (if applicable) of the corresponding issue.

# Quality Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

# UI Checklist
- [x] I have conducted visual UAT on my changes/features.
- [x] My solution works well on desktop, tablet, and mobile browsers.