### PR TITLE
fix(OptionTile): prevent line-height from being accidentally overridden by parent

### DIFF
--- a/src/components/Card/Card.Overview.stories.mdx
+++ b/src/components/Card/Card.Overview.stories.mdx
@@ -306,7 +306,7 @@ Here are some common use cases of `<Card />`.
     <Box alignItems="center" alignContent="center" padding="2xl" background="grey-lightest">
       <Card width="300px">
         <Card.Section padding="0" overflow="hidden" height="300px">
-          <img src="https://images.unsplash.com/photo-1555412654-72a95a495858?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=600&q=80" />
+          <img src="https://images.unsplash.com/photo-1555412654-72a95a495858?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=600&q=80" data-chromatic="ignore" />
         </Card.Section>
         <Card.Section childGap="xs">
           <Heading>Headline</Heading>

--- a/src/components/OptionTile/OptionTile.Overview.stories.mdx
+++ b/src/components/OptionTile/OptionTile.Overview.stories.mdx
@@ -204,6 +204,7 @@ If you require theming for this component separately of other form controls, it 
         '--option-tile-border-color': { global: '--form-control-border-color', default: '--color-brand-grey-100' },
         '--option-tile-border-radius': { global: '--form-control-size-md-border-radius', default: '--size-border-radius-md' },
         '--option-tile-font-family': { global: '--form-control-font-family', default: '--asset-fonts-body' },
+        '--option-tile-line-height': { global: '--form-control-line-height', default: '--size-line-height-input' },
         '--option-tile-border-color-hover': { global: '--form-control-border-color-hover', default: '--color-brand-grey-300' },
         '--option-tile-background-color-disabled': { global: '--form-control-background-color-disabled', default: '--color-brand-grey-50' },
         '--option-tile-font-color-disabled': { global: '--form-control-font-color-disabled', default: '--color-brand-grey-300' },

--- a/src/components/OptionTile/OptionTile.module.scss
+++ b/src/components/OptionTile/OptionTile.module.scss
@@ -3,7 +3,7 @@
   border: 1px solid var(--option-tile-border-color, var(--form-control-border-color, var(--INTERNAL_form-control-border-color)));
   border-radius: var(--option-tile-border-radius, var(--form-control-size-md-border-radius, var(--INTERNAL_form-control-size-md-border-radius)));
   font-family: var(--option-tile-font-family, var(--form-control-font-family, var(--INTERNAL_form-control-font-family)));
-  line-height: var(--form-control-line-height, var(--INTERNAL_form-control-line-height));
+  line-height: var(--option-tile-line-height, var(--form-control-line-height, var(--INTERNAL_form-control-line-height)));
 
   &:focus-within {
     box-shadow: var(--form-control-box-shadow-focus, var(--INTERNAL_form-control-box-shadow-focus)),

--- a/src/components/OptionTile/OptionTile.module.scss
+++ b/src/components/OptionTile/OptionTile.module.scss
@@ -3,6 +3,7 @@
   border: 1px solid var(--option-tile-border-color, var(--form-control-border-color, var(--INTERNAL_form-control-border-color)));
   border-radius: var(--option-tile-border-radius, var(--form-control-size-md-border-radius, var(--INTERNAL_form-control-size-md-border-radius)));
   font-family: var(--option-tile-font-family, var(--form-control-font-family, var(--INTERNAL_form-control-font-family)));
+  line-height: var(--form-control-line-height, var(--INTERNAL_form-control-line-height));
 
   &:focus-within {
     box-shadow: var(--form-control-box-shadow-focus, var(--INTERNAL_form-control-box-shadow-focus)),


### PR DESCRIPTION
This PR addresses this issue: https://github.com/palmetto/palmetto-components/issues/800

Use the form-control line-height token.

# What type of change is this?
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Updating documentation.
- [ ] Updating deployment/build pipeline.
- [ ] Updating Project Dependencies
- [ ] Improving or adding to Test Coverage

# Completeness Checklist

- [x] TESTS: My changes maintain the baseline required test coverage, as specified by code climate analysis.
- [x] DOCS: All new component work is covered in that component's `Overview` docs.
- [ ] DOCS: All new component work is covered in a component `Playground`.
- [ ] DOCS: All new visual changes or options are covered under relevant components' `VisualTests`.
- [x] My code has no linting or typescript compile warnings.
- [x] My work is tied to a Github issue and satisfies the acceptance criteria (if applicable) of the corresponding issue.

# Quality Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

# UI Checklist
- [x] I have conducted visual UAT on my changes/features.
- [x] My solution works well on desktop, tablet, and mobile browsers.