### PR TITLE
Allow OptionTileGroup options to have individual errors

### DIFF
--- a/src/components/OptionTileGroup/OptionTileGroup.Overview.stories.mdx
+++ b/src/components/OptionTileGroup/OptionTileGroup.Overview.stories.mdx
@@ -64,14 +64,14 @@ now being an array of values.
   <Story name="MultiSelect">
     {() => {
       const [value, setValue] = useState([]);
-      const handleSetValue = (event) => {
+      const handleSetValue = event => {
         const selectedValue = event.target.value;
         if (value.includes(selectedValue)) {
-          setValue([...value].filter(v => v !== selectedValue))
+          setValue([...value].filter(v => v !== selectedValue));
         } else {
           setValue([...value, selectedValue]);
         }
-      }
+      };
       const options = [
         {
           id: 'chocolate_multi',
@@ -168,7 +168,9 @@ Set the direction (flex) of the tiles. It can be one of `row` or `column` but wi
       ];
       return (
         <>
-          <p className="m-bottom-md font-size-lg font-weight-bold">Responsive Direction (change your viewport to see it in action)</p>
+          <p className="m-bottom-md font-size-lg font-weight-bold">
+            Responsive Direction (change your viewport to see it in action)
+          </p>
           <OptionTileGroup
             name="directionVertical"
             value={valueVertical}
@@ -269,14 +271,14 @@ A `disabled` attribute can be passed inside the `Option` object to disable any p
     {() => {
       const [value, setValue] = useState();
       const [valueMulti, setValueMulti] = useState([]);
-      const handleSetValueMulti = (event) => {
+      const handleSetValueMulti = event => {
         const selectedValue = event.target.value;
         if (valueMulti.includes(selectedValue)) {
-          setValueMulti([...valueMulti].filter(v => v !== selectedValue))
+          setValueMulti([...valueMulti].filter(v => v !== selectedValue));
         } else {
           setValueMulti([...valueMulti, selectedValue]);
         }
-      }
+      };
       const options = [
         {
           id: 'chocolate_disabled',
@@ -377,6 +379,44 @@ Pass an error (or boolean with no message) to notify a user when something isn't
   </Story>
 </Canvas>
 
+Pass an `error` to an individual option to indicate that something about that specific option is invalid.
+
+<Canvas isExpanded>
+  <Story name="Single Error">
+    {() => {
+      const [value, setValue] = useState('strawberry');
+      const options = [
+        {
+          id: 'chocolate_error2',
+          value: 'chocolate',
+          label: 'Chocolate',
+        },
+        {
+          id: 'strawberry_error2',
+          value: 'strawberry',
+          label: 'Strawberry',
+          error: 'single error',
+        },
+        {
+          id: 'vanilla_error2',
+          value: 'vanilla',
+          label: 'Vanilla',
+        },
+      ];
+      return (
+        <OptionTileGroup
+          name="required"
+          title="Ice cream flavors"
+          description="Only if you eat all your dinner"
+          isRequired
+          value={value}
+          onChange={event => setValue(event.target.value)}
+          options={options}
+        />
+      );
+    }}
+  </Story>
+</Canvas>
 
 ## Full Width (or lack thereof)
 

--- a/src/components/OptionTileGroup/OptionTileGroup.tsx
+++ b/src/components/OptionTileGroup/OptionTileGroup.tsx
@@ -102,8 +102,8 @@ export const OptionTileGroup: ForwardRefExoticComponent<OptionTileGroupProps> = 
 
     return value === option.value;
   };
-    
-  const hasAnyError = !!error || options.some((option) => !!option.error);
+
+  const hasAnyError = !!error || options.some(option => !!option.error);
 
   return (
     <Box

--- a/src/components/OptionTileGroup/OptionTileGroup.tsx
+++ b/src/components/OptionTileGroup/OptionTileGroup.tsx
@@ -102,6 +102,8 @@ export const OptionTileGroup: ForwardRefExoticComponent<OptionTileGroupProps> = 
 
     return value === option.value;
   };
+    
+  const hasAnyError = !!error || options.some((option) => !!option.error);
 
   return (
     <Box
@@ -123,7 +125,7 @@ export const OptionTileGroup: ForwardRefExoticComponent<OptionTileGroupProps> = 
             as="legend"
             display="block"
             margin="0 0 md 0"
-            color={error ? 'danger' : 'dark'}
+            color={hasAnyError ? 'danger' : 'dark'}
             fontSize="sm"
             fontWeight="bold"
           >

--- a/src/components/OptionTileGroup/OptionTileGroup.tsx
+++ b/src/components/OptionTileGroup/OptionTileGroup.tsx
@@ -10,6 +10,7 @@ interface Option {
   value: string;
   label: string;
   disabled?: boolean;
+  error?: boolean | string;
   render?: (option: {
     id: string;
     value: string;
@@ -150,7 +151,7 @@ export const OptionTileGroup: ForwardRefExoticComponent<OptionTileGroupProps> = 
             disabled={option.disabled}
             inputType={isMulti ? 'checkbox' : 'radio'}
             hideInput={hideInput}
-            error={!!error}
+            error={!!option.error || !!error}
             id={option.id}
             name={name}
           >


### PR DESCRIPTION
Now, only the "Loanpal 20 Year 3.99%" appears as if it has an error

![image](https://user-images.githubusercontent.com/4637120/233228471-b36b9813-39e2-4913-b277-9d10fd2416bb.png)

![image](https://user-images.githubusercontent.com/4637120/233228955-6fa0487a-548a-4d6b-82da-36f09ef45012.png)

