### PR TITLE
feat (Toggle): error state for Toggles that are on

### DIFF
--- a/src/components/Toggle/Toggle.Overview.stories.mdx
+++ b/src/components/Toggle/Toggle.Overview.stories.mdx
@@ -201,15 +201,26 @@ Use the `error` prop to mark the input as invalid. `error` accepts a `boolean`, 
   >
     {() => {
       const [value, setValue] = useState(null);
+      const [value2, setValue2] = useState(true);
       return (
-        <Toggle
-          id="invalidToggle"
-          label="Label"
-          isChecked={value}
-          onChange={value => setValue(event.target.checked)}
-          isRequired
-          error="You must accept the Terms and Conditions"
-        />
+        <Box childGap="md">
+          <Toggle
+            id="invalidToggle"
+            label="Agree to Terms and Conditions"
+            isChecked={value}
+            onChange={value => setValue(event.target.checked)}
+            isRequired
+            error="You must accept the Terms and Conditions"
+          />
+          <Toggle
+            id="invalidToggle2"
+            label="Roof Replacement"
+            isChecked={value2}
+            onChange={value2 => setValue2(event.target.checked)}
+            isRequired
+            error="Site Improvements can not be present with PPA"
+          />
+        </Box>
       );
     }}
   </Story>

--- a/src/components/Toggle/Toggle.Overview.stories.mdx
+++ b/src/components/Toggle/Toggle.Overview.stories.mdx
@@ -217,7 +217,6 @@ Use the `error` prop to mark the input as invalid. `error` accepts a `boolean`, 
             label="Roof Replacement"
             isChecked={value2}
             onChange={value2 => setValue2(event.target.checked)}
-            isRequired
             error="Site Improvements can not be present with PPA"
           />
         </Box>

--- a/src/components/Toggle/Toggle.module.scss
+++ b/src/components/Toggle/Toggle.module.scss
@@ -201,6 +201,10 @@
     background-color: var(--color-brand-primary-500);
   }
 
+  &:checked + .toggle-track.error {
+    background-color: var(--toggle-background-color-error, var(--color-brand-danger-500));
+  }
+
   &:checked + .toggle-track .toggle-thumb.thumb-size-sm {
     transform: translateX(0.5rem);
   }


### PR DESCRIPTION
Adds a visual error state for Toggles that's checked on. 

<img width="385" alt="Screen Shot 2023-05-05 at 12 46 31 PM" src="https://user-images.githubusercontent.com/1447339/236555364-e0ca2ce4-5b87-4cd6-8b41-35988ed136f9.png">


# What type of change is this?
Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Updating documentation.
- [ ] Updating deployment/build pipeline.
- [ ] Updating Project Dependencies
- [ ] Improving or adding to Test Coverage

# Completeness Checklist

- [ ] TESTS: My changes maintain the baseline required test coverage, as specified by code climate analysis.
- [ ] DOCS: All new component work is covered in that component's `Overview` docs.
- [ ] DOCS: All new component work is covered in a component `Playground`.
- [ ] DOCS: All new visual changes or options are covered under relevant components' `VisualTests`.
- [ ] My code has no linting or typescript compile warnings.
- [ ] My work is tied to a Github issue and satisfies the acceptance criteria (if applicable) of the corresponding issue.

# Quality Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

# UI Checklist
- [ ] I have conducted visual UAT on my changes/features.
- [ ] My solution works well on desktop, tablet, and mobile browsers.