### PR TITLE
Make Table expandedRow and onExpandedRowChange types consistent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 Changelog
 
+# [2.5.0](https://github.com/palmetto/palmetto-components/compare/v2.4.0...v2.5.0) (2025-05-06)
+
+
+### Features
+
+* update token package ([a5cc5eb](https://github.com/palmetto/palmetto-components/commit/a5cc5ebe36c4e6c2354e1ead0ccc7cc24a933f33))
+
 # [2.4.0](https://github.com/palmetto/palmetto-components/compare/v2.3.0...v2.4.0) (2025-04-17)
 
 

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -44,9 +44,9 @@ export interface TableProps {
    * Remove borders around table, thead, tbody, td, etc.
    */
   isBorderless?: boolean;
-   /**
-   * Make Table more compact by cutting cell padding in half.
-   */
+  /**
+  * Make Table more compact by cutting cell padding in half.
+  */
   isCompact?: boolean;
   /**
    * If table scrolls vertically, header will remain stuck to the top of the table, and not scroll away.
@@ -101,7 +101,7 @@ export interface TableProps {
   /**
    * Callback when row expand state changes
    */
-  onExpandedRowChange?: (expandedRow: React.Key | null) => void;
+  onExpandedRowChange?: (expandedRow: React.Key | undefined) => void;
   /**
    * Labels for expand/collapse actions
    */

--- a/src/components/Table/TableBody/TableBody.tsx
+++ b/src/components/Table/TableBody/TableBody.tsx
@@ -57,11 +57,11 @@ export interface TableBodyProps {
   /**
    * Currently expanded row key
    */
-  expandedRow?: React.Key | null;
+  expandedRow?: React.Key;
   /**
    * Callback when row expand state changes
    */
-  onExpandedRowChange?: (rowId: React.Key | null) => void;
+  onExpandedRowChange?: (rowId: React.Key | undefined) => void;
   expandLabels?: {
     expand: string;
     collapse: string;
@@ -101,8 +101,8 @@ export const TableBody: FC<TableBodyProps> = ({
     className,
   );
 
-  const handleExpand = (rowId: React.Key | null) => {
-    onExpandedRowChange?.(rowId === expandedRow ? null : rowId);
+  const handleExpand = (rowId: React.Key | undefined) => {
+    onExpandedRowChange?.(rowId === expandedRow ? undefined : rowId);
   };
 
   return (

--- a/src/hooks/useExpandableRow/useExpandableRow.test.tsx
+++ b/src/hooks/useExpandableRow/useExpandableRow.test.tsx
@@ -38,7 +38,7 @@ describe('useExpandableRow', () => {
   });
 
   describe('uncontrolled behavior', () => {
-    test('initializes with null expandedRow', () => {
+    test('initializes with undefined expandedRow', () => {
       const { getByTestId } = render(<UseExpandableRowExample />);
       expect(getByTestId('expanded-row').textContent).toBe('');
     });
@@ -56,7 +56,7 @@ describe('useExpandableRow', () => {
 
       fireEvent.click(getByTestId('toggle-row1'));
       expect(getByTestId('expanded-row').textContent).toBe('');
-      expect(mockOnExpandedRowChange).toHaveBeenCalledWith(null);
+      expect(mockOnExpandedRowChange).toHaveBeenCalledWith(undefined);
     });
 
     test('changes to different row when another row is toggled', () => {
@@ -97,7 +97,7 @@ describe('useExpandableRow', () => {
 
       fireEvent.click(getByTestId('toggle-row1'));
       expect(getByTestId('expanded-row').textContent).toBe('row1');
-      expect(mockOnExpandedRowChange).toHaveBeenCalledWith(null);
+      expect(mockOnExpandedRowChange).toHaveBeenCalledWith(undefined);
 
       fireEvent.click(getByTestId('toggle-row2'));
       expect(getByTestId('expanded-row').textContent).toBe('row1');

--- a/src/hooks/useExpandableRow/useExpandableRow.ts
+++ b/src/hooks/useExpandableRow/useExpandableRow.ts
@@ -2,12 +2,12 @@ import { useState, useCallback } from 'react';
 
 export interface UseExpandableRowProps {
   expandedRow?: React.Key;
-  onExpandedRowChange?: (expandedRow: React.Key | null) => void;
+  onExpandedRowChange?: (expandedRow: React.Key | undefined) => void;
 }
 export const useExpandableRow = (props: UseExpandableRowProps = {}) => {
   const { expandedRow: controlledExpandedRow, onExpandedRowChange } = props;
 
-  const [internalExpandedRow, setInternalExpandedRow] = useState<React.Key | null>(null);
+  const [internalExpandedRow, setInternalExpandedRow] = useState<React.Key | undefined>(undefined);
 
   const isControlled = controlledExpandedRow !== undefined;
   const currentExpandedRow = isControlled
@@ -15,8 +15,8 @@ export const useExpandableRow = (props: UseExpandableRowProps = {}) => {
     : internalExpandedRow;
 
   const handleToggle = useCallback(
-    (rowId: React.Key | null) => {
-      const newExpandedRow = currentExpandedRow === rowId ? null : rowId;
+    (rowId: React.Key | undefined) => {
+      const newExpandedRow = currentExpandedRow === rowId ? undefined : rowId;
 
       if (!isControlled) {
         setInternalExpandedRow(newExpandedRow);


### PR DESCRIPTION
# Github Issue or Trello Card
This PR addresses this issue: 

Types for `expandedRow` (`Key | undefined`) and `onExpandedRowChange` (`Dispatch<SetStateAction<Key | null>>`) did not match, causing one or the other to always have a type error:

![2025-05-09_16-31](https://github.com/user-attachments/assets/9d29c20b-e86a-4329-8504-199236e57a6c)
![2025-05-09_16-31_1](https://github.com/user-attachments/assets/bf17e75f-41b4-4168-92aa-874388e7560d)


# What type of change is this?
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Completeness Checklist

- [x] TESTS: My changes maintain the baseline required test coverage, as specified by code climate analysis.
- [x] My code has no linting or typescript compile warnings.

# Quality Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

# UI Checklist
- [ ] I have conducted visual UAT on my changes/features.
- [ ] My solution works well on desktop, tablet, and mobile browsers.