### PR TITLE
fix: update styling for light and dark mode

### DIFF
--- a/src/components/SelectInput/SelectInput.module.scss
+++ b/src/components/SelectInput/SelectInput.module.scss
@@ -1,4 +1,5 @@
 @import '~@palmetto/palmetto-design-tokens/build/scss/variables-size';
+
 // The following styles required the :global tag since they need to be applied to react-select elements for which we do not own the markup
 
 @mixin react-select-icon {
@@ -17,6 +18,27 @@
 
 .react-select-icon {
   @extend %react-select-icon;
+}
+
+:global(.react-select__control) {
+  :global(.react-select__multi-value) {
+    border-radius: var(--size-border-radius-md, 8px);
+    background-color: var(--color-text-contrast);
+    color: var(--color-background-form-control);
+  }
+
+  :global(.react-select__multi-value__label) {
+    color: var(--color-background-form-control);
+  }
+
+  :global(.react-select__multi-value__remove) {
+    &:hover {
+      border-top-right-radius: var(--size-border-radius-md, 8px);
+      border-bottom-right-radius: var(--size-border-radius-md, 8px);
+      background-color: var(--color-text-body-secondary);
+      color: var(--color-background-form-control);
+    }
+  }
 }
 
 // stylelint-disable
@@ -91,6 +113,8 @@
       var(--INTERNAL_form-control-size-md-font-size)
     );
   }
+
+ 
 
   :global(.react-select__multi-value__label) {
     font-size: var(

--- a/src/components/SelectInput/SelectInput.module.scss
+++ b/src/components/SelectInput/SelectInput.module.scss
@@ -1,5 +1,4 @@
 @import '~@palmetto/palmetto-design-tokens/build/scss/variables-size';
-
 // The following styles required the :global tag since they need to be applied to react-select elements for which we do not own the markup
 
 @mixin react-select-icon {
@@ -113,8 +112,6 @@
       var(--INTERNAL_form-control-size-md-font-size)
     );
   }
-
- 
 
   :global(.react-select__multi-value__label) {
     font-size: var(


### PR DESCRIPTION
# Github Issue or Trello Card
This PR addresses this issue: 

Updates styles for multiselect component for light and dark mode.

<img width="1163" alt="Screenshot 2025-06-04 at 9 13 12 AM" src="https://github.com/user-attachments/assets/732b541c-f6dd-4736-88d4-767dcf3ce495" />
<img width="1193" alt="Screenshot 2025-06-04 at 9 12 55 AM" src="https://github.com/user-attachments/assets/9dfd106c-d757-4759-bde3-622691e4dca4" />

# What type of change is this?
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Updating documentation.
- [ ] Updating deployment/build pipeline.
- [ ] Updating Project Dependencies
- [ ] Improving or adding to Test Coverage

# Completeness Checklist

- [x] TESTS: My changes maintain the baseline required test coverage, as specified by code climate analysis.
- [ ] DOCS: All new component work is covered in that component's `Overview` docs.
- [x] DOCS: All new component work is covered in a component `Playground`.
- [x] DOCS: All new visual changes or options are covered under relevant components' `VisualTests`.
- [x] My code has no linting or typescript compile warnings.
- [ ] My work is tied to a Github issue and satisfies the acceptance criteria (if applicable) of the corresponding issue.

# Quality Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

# UI Checklist
- [x] I have conducted visual UAT on my changes/features.
- [x] My solution works well on desktop, tablet, and mobile browsers.