### PR TITLE
fix: [CA-188] Remove disableAutoScroll from Tabs component (optional prop)

### DIFF
--- a/src/components/Tabs/Tabs.tsx
+++ b/src/components/Tabs/Tabs.tsx
@@ -15,6 +15,7 @@ export interface TabsProps extends BoxProps {
   isFullWidth?: boolean;
   isCentered?: boolean;
   size?: 'sm' | 'md' | ResponsiveProp<'sm' | 'md'>;
+  disableAutoScroll?: boolean;
 }
 
 const TabsBaseComponent: React.FC<TabsProps> = React.forwardRef(
@@ -24,6 +25,7 @@ const TabsBaseComponent: React.FC<TabsProps> = React.forwardRef(
       borderWidth = '0 0 xs 0',
       borderColor = 'separator',
       children,
+      disableAutoScroll = false,
       isCentered = false,
       isFullWidth = false,
       onChange,
@@ -83,12 +85,12 @@ const TabsBaseComponent: React.FC<TabsProps> = React.forwardRef(
     });
 
     React.useEffect(() => {
-      if (activeTabRef.current) {
+      if (!disableAutoScroll && activeTabRef.current) {
         activeTabRef.current.scrollIntoView({
           behavior: 'smooth',
         });
       }
-    }, []);
+    }, [disableAutoScroll]);
 
     return (
       <Box


### PR DESCRIPTION
This PR implements a retro-compatible fix at the Tabs component. This scroll is causing an issue with height calculation, so I created a prop to disable it (and when it is not passed, the behaviour is the same as before)

# Github Issue or Trello Card
This PR addresses this issue: 
https://palmetto.atlassian.net/browse/CA-188
(The ticket description is misleading; the actual problem is below the navbar, the full conversation is here with the clarification: https://palmetto-team.slack.com/archives/C094N25HEDT/p1767749815107449)

After this change, the result is the layout fixed
<img width="626" height="804" alt="Screenshot 2026-01-08 at 12 16 29" src="https://github.com/user-attachments/assets/d1f2fe07-ef3b-4431-8f4c-f396840f6b93" />

# What type of change is this?
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Updating documentation.
- [ ] Updating deployment/build pipeline.
- [ ] Updating Project Dependencies
- [ ] Improving or adding to Test Coverage

# Completeness Checklist

- [x] TESTS: My changes maintain the baseline required test coverage, as specified by code climate analysis.
- [x] DOCS: All new component work is covered in that component's `Overview` docs.
- [x] DOCS: All new component work is covered in a component `Playground`.
- [x] DOCS: All new visual changes or options are covered under relevant components' `VisualTests`.
- [x] My code has no linting or typescript compile warnings.
- [x] My work is tied to a Github issue and satisfies the acceptance criteria (if applicable) of the corresponding issue.

# Quality Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

# UI Checklist
- [x] I have conducted visual UAT on my changes/features.
- [x] My solution works well on desktop, tablet, and mobile browsers.